### PR TITLE
Add lotto summary on index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,26 @@
     <h1>Historical Lotto Results</h1>
 </header>
 <main>
+    <h2>Summary</h2>
+    <table>
+        <tr><th>Total Tickets Bought</th><td>44</td></tr>
+        <tr><th>Total Win Numbers</th><td>35</td></tr>
+    </table>
+    <h3>Matched Count Distribution</h3>
+    <table>
+        <thead>
+        <tr><th>Matched Numbers</th><th>Ticket Count</th></tr>
+        </thead>
+        <tbody>
+        <tr><td>0</td><td>12</td></tr>
+        <tr><td>1</td><td>27</td></tr>
+        <tr><td>2</td><td>4</td></tr>
+        <tr><td>3</td><td>0</td></tr>
+        <tr><td>4</td><td>0</td></tr>
+        <tr><td>5</td><td>0</td></tr>
+        <tr><td>6</td><td>0</td></tr>
+        </tbody>
+    </table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table>

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -64,6 +64,20 @@
     <h1>Historical Lotto Results</h1>
 </header>
 <main>
+    <h2>Summary</h2>
+    <table>
+        <tr><th>Total Tickets Bought</th><td>{{ total_tickets }}</td></tr>
+        <tr><th>Total Win Numbers</th><td>{{ total_win_numbers }}</td></tr>
+    </table>
+    <h3>Matched Count Distribution</h3>
+    <table>
+        <thead>
+        <tr><th>Matched Numbers</th><th>Ticket Count</th></tr>
+        </thead>
+        <tbody>
+        {{ matched_distribution_rows }}
+        </tbody>
+    </table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table>


### PR DESCRIPTION
## Summary
- summarize total tickets bought, total matched numbers, and distribution of match counts
- display the summary on the lotto results page in tables
- rename `match` variables to `matched`

## Testing
- `python3 -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d7503d9488324b2db2589504b2073