### PR TITLE
Add predict_number_sources columns

### DIFF
--- a/utils/llm_predict.py
+++ b/utils/llm_predict.py
@@ -66,7 +66,7 @@ class LargeLanguageModel:
             response = self.deepseek_request(prompt)
         else:
             response = self.openai_request(prompt)
-        self.db.save_predict_nums(last_lotto_date, prompt, response)
+        self.db.save_predict_nums(last_lotto_date, prompt, response, source="LLM")
         return response
 
 


### PR DESCRIPTION
## Summary
- track source of predicted numbers in the database
- default all stored predictions to `LLM`
- revert accidental change to lotto database

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 auto_stock/test_all.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c3108a083248d59be23d8c0d0a7