### PR TITLE
Add predict_number_sources column

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -28,6 +28,9 @@ def update_html_with_win_status_and_predict_number():
     for each_data in all_buying_history:
         predict_nums = MY_DB.get_predict_nums(each_data["last_lotto_date"])
         each_data["predict_nums"] = predict_nums
+        # ensure predict_number_sources always has a value
+        if not each_data.get("predict_number_sources"):
+            each_data["predict_number_sources"] = "LLM"
         matched = re.search(r"match (\d+) number", each_data["win_status"])
         if matched:
             count = int(matched.group(1))
@@ -50,6 +53,7 @@ def update_html_with_win_status_and_predict_number():
         one_row.append(f"<td>{each_data['bought_numbers']}</td>")
         one_row.append(f"<td>{each_data['win_status']}</td>")
         one_row.append(f"<td>{each_data['predict_nums']}</td>")
+        one_row.append(f"<td>{each_data['predict_number_sources']}</td>")
         format_buying_history.append(f"<tr>{''.join(one_row)}</tr>")
 
     # update to html

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,12 +93,13 @@
                 <th>Bought Numbers</th>
                 <th>Win Status</th>
                 <th>LLM Predict Results</th>
+                <th>Predict Number Sources</th>
             </tr>
             </thead>
             <tbody>
             <tr><td>2025-06-25</td><td>02-07-15-22-31-39</td><td>empty</td><td>{
   "generate_nums": ["02", "07", "15", "22", "31", "39"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-21</td><td>02-14-22-35-39-46</td><td>match 0 number, win number: The Classic Draw
 
 
@@ -112,7 +113,7 @@
     "39",
     "46"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-18</td><td>05-12-19-23-34-39</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -126,91 +127,91 @@
     "34",
     "39"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-14</td><td>03-12-22-28-34-41</td><td>match 0 number, win number: The Classic Draw
 
 
 08-14-20-25-30-38 Bonus (B):
 (46)</td><td>{
   "generate_nums": ["03", "12", "22", "28", "34", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-11</td><td>02-11-18-26-35-41</td><td>match 1 number, win number: The Classic Draw
 
 
 05-08-20-28-35-38 Bonus (B):
 (46)</td><td>{
   "generate_nums": ["02", "11", "18", "26", "35", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-07</td><td>01-10-20-25-30-40</td><td>match 0 number, win number: The Classic Draw
 
 
 04-09-23-28-32-39 Bonus (B):
 (26)</td><td>{
   "generate_nums": ["01", "10", "20", "25", "30", "40"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-06-04</td><td>04-17-23-31-36-42</td><td>match 1 number, win number: The Classic Draw
 
 
 02-10-12-21-36-41 Bonus (B):
 (33)</td><td>{
   "generate_nums": ["04", "17", "23", "31", "36", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-31</td><td>02-13-21-29-36-41</td><td>match 1 number, win number: The Classic Draw
 
 
 08-20-30-39-41-48 Bonus (B):
 (18)</td><td>{
   "generate_nums": ["02", "13", "21", "29", "36", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-28</td><td>04-12-21-28-35-42</td><td>match 1 number, win number: The Classic Draw
 
 
 02-04-11-26-34-37 Bonus (B):
 (24)</td><td>{
   "generate_nums": ["04", "12", "21", "28", "35", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-24</td><td>07-12-18-24-35-42</td><td>match 1 number, win number: The Classic Draw
 
 
 06-13-28-31-34-48 Bonus (B):
 (42)</td><td>{
   "generate_nums": ["07", "12", "18", "24", "35", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-21</td><td>07-11-18-29-34-42</td><td>match 1 number, win number: The Classic Draw
 
 
 04-08-18-27-28-31 Bonus (B):
 (48)</td><td>{
   "generate_nums": ["07", "11", "18", "29", "34", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-17</td><td>07-12-19-24-32-40</td><td>match 1 number, win number: The Classic Draw
 
 
 01-02-37-38-43-46 Bonus (B):
 (40)</td><td>{
   "generate_nums": ["07", "12", "19", "24", "32", "40"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-14</td><td>07-16-25-30-41-44</td><td>match 1 number, win number: The Classic Draw
 
 
 07-09-20-34-38-46 Bonus (B):
 (14)</td><td>{
   "generate_nums": ["07", "16", "25", "30", "41", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-10</td><td>05-11-18-24-30-36</td><td>match 1 number, win number: The Classic Draw
 
 
 01-08-17-18-41-48 Bonus (B):
 (42)</td><td>{
   "generate_nums": ["05", "11", "18", "24", "30", "36"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-07</td><td>03-07-18-21-36-42</td><td>match 0 number, win number: The Classic Draw
 
 
 05-12-17-19-40-47 Bonus (B):
 (29)</td><td>{
   "generate_nums": ["03", "07", "18", "21", "36", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-05-03</td><td>01-09-12-23-37-44</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -224,42 +225,42 @@
     "37",
     "44"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-30</td><td>03-17-22-29-35-41</td><td>match 2 number, win number: The Classic Draw
 
 
 12-22-25-30-36-41 Bonus (B):
 (14)</td><td>{
   "generate_nums": ["03", "17", "22", "29", "35", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-26</td><td>02-11-18-26-35-42</td><td>match 1 number, win number: The Classic Draw
 
 
 01-09-12-15-34-35 Bonus (B):
 (31)</td><td>{
   "generate_nums": ["02", "11", "18", "26", "35", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-23</td><td>03-12-19-25-34-42</td><td>match 0 number, win number: The Classic Draw
 
 
 18-22-28-32-38-44 Bonus (B):
 (20)</td><td>{
   "generate_nums": ["03", "12", "19", "25", "34", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-19</td><td>10-18-25-32-36-44</td><td>match 1 number, win number: The Classic Draw
 
 
 09-15-22-24-40-49 Bonus (B):
 (25)</td><td>{
   "generate_nums": ["10", "18", "25", "32", "36", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-16</td><td>02-14-18-27-35-43</td><td>match 1 number, win number: The Classic Draw
 
 
 01-07-31-35-46-49 Bonus (B):
 (29)</td><td>{
   "generate_nums": ["02", "14", "18", "27", "35", "43"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-12</td><td>12-20-26-31-39-45</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -273,7 +274,7 @@
     "39",
     "45"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-09</td><td>02-12-20-31-38-45</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -287,70 +288,70 @@
     "38",
     "45"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-05</td><td>01-12-23-34-42-46</td><td>match 0 number, win number: The Classic Draw
 
 
 11-18-26-35-37-39 Bonus (B):
 (16)</td><td>{
   "generate_nums": ["01", "12", "23", "34", "42", "46"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-04-02</td><td>07-15-22-31-36-44</td><td>match 1 number, win number: The Classic Draw
 
 
 02-14-23-29-39-42 Bonus (B):
 (15)</td><td>{
   "generate_nums": ["07", "15", "22", "31", "36", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-29</td><td>03-12-26-34-40-41</td><td>match 2 number, win number: The Classic Draw
 
 
 18-26-35-40-43-47 Bonus (B):
 (24)</td><td>{
   "generate_nums": ["03", "12", "26", "34", "40", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-26</td><td>02-07-13-17-30-36</td><td>match 0 number, win number: The Classic Draw
 
 
 14-23-24-27-34-42 Bonus (B):
 (43)</td><td>{
   "generate_nums": ["02", "07", "13", "17", "30", "36"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-22</td><td>02-14-26-34-37-45</td><td>match 1 number, win number: The Classic Draw
 
 
 09-13-25-30-45-49 Bonus (B):
 (08)</td><td>{
   "generate_nums": ["02", "14", "26", "34", "37", "45"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-19</td><td>02-12-21-30-38-44</td><td>match 1 number, win number: The Classic Draw
 
 
 01-03-13-16-26-32 Bonus (B):
 (21)</td><td>{
   "generate_nums": ["02", "12", "21", "30", "38", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-15</td><td>12-16-23-28-33-45</td><td>match 1 number, win number: The Classic Draw
 
 
 06-07-28-32-44-48 Bonus (B):
 (18)</td><td>{
   "generate_nums": ["12", "16", "23", "28", "33", "45"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-12</td><td>04-11-19-27-36-42</td><td>match 1 number, win number: The Classic Draw
 
 
 19-31-32-37-38-39 Bonus (B):
 (34)</td><td>{
   "generate_nums": ["04", "11", "19", "27", "36", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-08</td><td>03-11-23-28-36-42</td><td>match 1 number, win number: The Classic Draw
 
 
 13-15-16-22-23-46 Bonus (B):
 (02)</td><td>{
   "generate_nums": ["03", "11", "23", "28", "36", "42"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-05</td><td>02-12-20-27-34-39</td><td>match 2 number, win number: The Classic Draw
 
 
@@ -364,14 +365,14 @@
     "34",
     "39"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-03-01</td><td>02-05-12-24-31-38</td><td>match 1 number, win number: The Classic Draw
 
 
 09-11-26-36-37-42 Bonus (B):
 (24)</td><td>{
   "generate_nums": ["02", "05", "12", "24", "31", "38"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-26</td><td>05-11-16-22-28-31</td><td>match 0 number, win number: The Classic Draw
 
 
@@ -385,28 +386,28 @@
     "28",
     "31"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-22</td><td>11-14-25-32-36-41</td><td>match 0 number, win number: The Classic Draw
 
 
 07-19-20-26-31-35 Bonus (B):
 (40)</td><td>{
   "generate_nums": ["11", "14", "25", "32", "36", "41"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-19</td><td>02-19-24-31-37-45</td><td>match 0 number, win number: The Classic Draw
 
 
 07-13-29-39-47-48 Bonus (B):
 (26)</td><td>{
   "generate_nums": ["02", "19", "24", "31", "37", "45"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-15</td><td>17-26-35-37-40-49</td><td>match 1 number, win number: The Classic Draw
 
 
 09-10-11-24-31-37 Bonus (B):
 (44)</td><td>{
   "generate_nums": ["17", "26", "35", "37", "40", "49"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-12</td><td>02-10-21-27-36-41</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -420,35 +421,35 @@
     "36",
     "41"
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-08</td><td>01-14-19-25-32-40</td><td>match 2 number, win number: The Classic Draw
 
 
 19-24-39-40-42-45 Bonus (B):
 (41)</td><td>{
   "generate_nums": ["01", "14", "19", "25", "32", "40"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-05</td><td>11-12-18-23-28-31</td><td>match 0 number, win number: The Classic Draw
 
 
 07-17-22-26-27-32 Bonus (B):
 (46)</td><td>{
   "generate_nums": ["11", "12", "18", "23", "28", "31"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-02-01</td><td>03-06-12-21-29-44</td><td>match 0 number, win number: The Classic Draw
 
 
 04-13-20-32-37-46 Bonus (B):
 (33)</td><td>{
   "generate_nums": ["03", "06", "12", "21", "29", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-01-29</td><td>12-15-21-28-37-44</td><td>match 1 number, win number: The Classic Draw
 
 
 02-28-29-30-36-49 Bonus (B):
 (35)</td><td>{
   "generate_nums": ["12", "15", "21", "28", "37", "44"]
-}</td></tr>
+}</td><td>LLM</td></tr>
 <tr><td>2025-01-25</td><td>["02", "09", "14", "21", "32", "41"]</td><td>match 1 number, win number: The Classic Draw
 
 
@@ -461,7 +462,7 @@
     ["05", "09", "16", "39", "44", "48"],
     ["06", "10", "13", "25", "30", "49"]
   ]
-}</td></tr>
+}</td><td>LLM</td></tr>
             </tbody>
         </table>
     </div>

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -87,6 +87,7 @@
                 <th>Bought Numbers</th>
                 <th>Win Status</th>
                 <th>LLM Predict Results</th>
+                <th>Predict Number Sources</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- extend DB output to show `predict_number_sources`
- show the new column in lotto results tables
- default to `LLM` if database value missing

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*

------
https://chatgpt.com/codex/tasks/task_e_685d8ec22a8c83248dc62168c63f40c7