### PR TITLE
Update lotto summary grouping

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -65,11 +65,13 @@
 </header>
 <main>
     <h2>Summary</h2>
+    <h3>LLM</h3>
     <table>
         <tr><th>Total Tickets Bought</th><td>44</td></tr>
         <tr><th>Total Win Numbers</th><td>35</td></tr>
     </table>
     <h3>Matched Count Distribution</h3>
+    <h3>LLM</h3>
     <table>
         <thead>
         <tr><th>Matched Numbers</th><th>Ticket Count</th></tr>

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -65,19 +65,9 @@
 </header>
 <main>
     <h2>Summary</h2>
-    <table>
-        <tr><th>Total Tickets Bought</th><td>{{ total_tickets }}</td></tr>
-        <tr><th>Total Win Numbers</th><td>{{ total_win_numbers }}</td></tr>
-    </table>
+    {{ summary_tables }}
     <h3>Matched Count Distribution</h3>
-    <table>
-        <thead>
-        <tr><th>Matched Numbers</th><th>Ticket Count</th></tr>
-        </thead>
-        <tbody>
-        {{ matched_distribution_rows }}
-        </tbody>
-    </table>
+    {{ matched_distribution_tables }}
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table>


### PR DESCRIPTION
## Summary
- group lotto summary by prediction source
- update template placeholders for grouped summaries
- adjust generated HTML example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*

------
https://chatgpt.com/codex/tasks/task_e_685d909bd3fc8324bb0170b880d1941f