### PR TITLE
Refactor random source option

### DIFF
--- a/utils/random_predict.py
+++ b/utils/random_predict.py
@@ -1,0 +1,26 @@
+#!/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate random lotto numbers."""
+import random
+from utils.common import logger
+from utils.custom_db import MyLottoDB
+
+
+class RandomLottoNumberGenerator:
+    """Simple random lotto number generator."""
+
+    def __init__(self):
+        self.db = MyLottoDB()
+
+    def predict(self, last_lotto_date):
+        numbers = random.sample(range(1, 50), 6)
+        numbers.sort()
+        result = "-".join(f"{n:02d}" for n in numbers)
+        self.db.save_predict_nums(
+            last_lotto_date,
+            {"method": "random"},
+            result,
+            source="RANDOM",
+        )
+        logger.info(f"Predict numbers: {result}")
+        return result


### PR DESCRIPTION
## Summary
- refactor random prediction into `RandomLottoNumberGenerator`
- merge `predict_random_next_lotto` logic into `predict_next_lotto`

## Testing
- `python -m py_compile auto_lotto_main.py utils/*.py auto_stock/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685d92c347048324b170b04c28966d24