### PR TITLE
Add hit rate chart to results page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>12</td></tr><tr><td>1</td><td>27</td></tr><tr><td>2</td><td>4</td></tr><tr><td>3</td><td>0</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
-        <table>
+        <table id="resultsTable">
             <thead>
             <tr>
                 <th>Last Lotto Date</th>
@@ -452,6 +452,43 @@
             </tbody>
         </table>
     </div>
+    <h2>Hit Rate Over Time</h2>
+    <canvas id="hitRateChart"></canvas>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const rows = document.querySelectorAll('#resultsTable tbody tr');
+            const labels = [];
+            const data = [];
+            rows.forEach(row => {
+                const cells = row.querySelectorAll('td');
+                const date = cells[0].textContent.trim();
+                const winText = cells[2].textContent;
+                const match = winText.match(/match\s+(\d+)/);
+                const count = match ? parseInt(match[1]) : 0;
+                labels.unshift(date);
+                data.unshift(count / 6);
+            });
+            const ctx = document.getElementById('hitRateChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Hit Rate',
+                        data: data,
+                        borderColor: 'blue',
+                        fill: false
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {beginAtZero: true, max: 1}
+                    }
+                }
+            });
+        });
+    </script>
 </main>
 </body>
 </html>

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -70,7 +70,7 @@
     {{ matched_distribution_tables }}
     <h2>Results</h2>
     <div style="overflow-x: auto;">
-        <table>
+        <table id="resultsTable">
             <thead>
             <tr>
                 <th>Last Lotto Date</th>
@@ -85,6 +85,43 @@
             </tbody>
         </table>
     </div>
+    <h2>Hit Rate Over Time</h2>
+    <canvas id="hitRateChart"></canvas>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const rows = document.querySelectorAll('#resultsTable tbody tr');
+            const labels = [];
+            const data = [];
+            rows.forEach(row => {
+                const cells = row.querySelectorAll('td');
+                const date = cells[0].textContent.trim();
+                const winText = cells[2].textContent;
+                const match = winText.match(/match\s+(\d+)/);
+                const count = match ? parseInt(match[1]) : 0;
+                labels.unshift(date);
+                data.unshift(count / 6);
+            });
+            const ctx = document.getElementById('hitRateChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Hit Rate',
+                        data: data,
+                        borderColor: 'blue',
+                        fill: false
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {beginAtZero: true, max: 1}
+                    }
+                }
+            });
+        });
+    </script>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a `Hit Rate Over Time` section
- parse results table with JavaScript and draw chart using Chart.js

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*

------
https://chatgpt.com/codex/tasks/task_e_685dc628e06883249bd8d5320d0d71a8