### PR TITLE
Add average hit rate to lotto summary

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -52,9 +52,14 @@ def update_html_with_win_status_and_predict_number():
     matched_distribution_tables = []
     for source, data in group_summary.items():
         summary_tables.append(f"<h3>{source}</h3>")
+        avg_hit_rate = 0
+        if data["total_tickets"] > 0:
+            avg_hit_rate = data["total_win_numbers"] / (data["total_tickets"] * 6)
+
         summary_tables.append(
             f"<table><tr><th>Total Tickets Bought</th><td>{data['total_tickets']}</td></tr>"
-            f"<tr><th>Total Win Numbers</th><td>{data['total_win_numbers']}</td></tr></table>"
+            f"<tr><th>Total Win Numbers</th><td>{data['total_win_numbers']}</td></tr>"
+            f"<tr><th>Average Hit Rate</th><td>{avg_hit_rate:.2%}</td></tr></table>"
         )
 
         matched_distribution_tables.append(f"<h3>{source}</h3>")

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
 <main>
     <h2>Summary</h2>
     <h3>LLM</h3>
-<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>35</td></tr></table>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>35</td></tr><tr><th>Average Hit Rate</th><td>13.26%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LLM</h3>
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>12</td></tr><tr><td>1</td><td>27</td></tr><tr><td>2</td><td>4</td></tr><tr><td>3</td><td>0</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>


### PR DESCRIPTION
## Summary
- compute average hit rate per source in `auto_lotto_main.py`
- display the average in `docs/index.html`

## Testing
- `python3 -m py_compile auto_lotto_main.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc8b7ca0883248f1d3a60539a1737