### PR TITLE
Add frequency-weighted lotto predictor

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -10,6 +10,7 @@ import json
 from utils.common import logger
 from utils.llm_predict import LargeLanguageModel
 from utils.random_predict import RandomLottoNumberGenerator
+from utils.frequency_predict import FrequencyWeightedPredictor
 from utils.collect_history_winner import history_year, current_year
 from utils.custom_db import MyLottoDB
 from utils.purchase_lotto_tickets import do_buying
@@ -140,6 +141,9 @@ def predict_next_lotto(last_lotto_date, source="LLM"):
 
     if source.upper() == "RANDOM":
         generator = RandomLottoNumberGenerator()
+        return generator.predict(last_lotto_date)
+    if source.upper() == "FREQ":
+        generator = FrequencyWeightedPredictor()
         return generator.predict(last_lotto_date)
 
     llm = LargeLanguageModel(model="openai")

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,11 @@ Key directories and files:
 
 ## Project1: Auto Lotto
 
-This project uses LLMs to generate lottery numbers, automatically purchase tickets, and verify winning statuses. 
+This project uses various strategies to generate lottery numbers, automatically purchase tickets, and verify winning statuses.
+The available predictors include:
+1. **LLM** - a language model suggests numbers based on recent draws.
+2. **Random** - generates purely random combinations.
+3. **Frequency-weighted** - analyzes the last two years of draws and selects the most common numbers.
 
 The purchased tickets and their results are displayed on GitHub Pages.
 [https://l1nwatch.github.io/auto_market/](https://l1nwatch.github.io/auto_market/)

--- a/utils/custom_db.py
+++ b/utils/custom_db.py
@@ -100,6 +100,28 @@ class MyLottoDB:
             results[f"{year}-{month:02}-{day:02}"] = value
         return results
 
+    def get_lotto_numbers_since(self, start_date):
+        """Return all lotto numbers from the given date (inclusive)."""
+        start_val = start_date.year * 10000 + start_date.month * 100 + start_date.day
+        sql = (
+            f"SELECT data FROM {self.table_name['history_lotto']} "
+            f"WHERE (year * 10000 + month * 100 + day) >= ? "
+            f"ORDER BY year ASC, month ASC, day ASC"
+        )
+        self.cursor.execute(sql, (start_val,))
+        rows = [r[0] for r in self.cursor.fetchall()]
+        results = []
+        for value in rows:
+            try:
+                data = json.loads(value)
+            except Exception:
+                continue
+            numbers = re.findall(r"\d{2}", json.dumps(data))
+            numbers = [int(n) for n in numbers[:7]]
+            if len(numbers) == 7:
+                results.append(numbers)
+        return results
+
     def save_results(self, data, expected_year):
         for date, value in data.items():
             year, month, day = date.split("-")

--- a/utils/frequency_predict.py
+++ b/utils/frequency_predict.py
@@ -1,0 +1,38 @@
+#!/bin/env python3
+# -*- coding: utf-8 -*-
+"""Frequency weighted lotto predictor."""
+import datetime
+from utils.common import logger
+from utils.custom_db import MyLottoDB
+
+
+class FrequencyWeightedPredictor:
+    """Predict lotto numbers using frequency analysis of past draws."""
+
+    def __init__(self):
+        self.db = MyLottoDB()
+
+    def _get_recent_numbers(self):
+        """Return lists of lotto numbers from the last two years."""
+        end = datetime.datetime.now()
+        start = end - datetime.timedelta(days=365 * 2)
+        return self.db.get_lotto_numbers_since(start)
+
+    def predict(self, last_lotto_date):
+        draws = self._get_recent_numbers()
+        freq = {i: 0 for i in range(1, 50)}
+        for draw in draws:
+            for num in draw:
+                if 1 <= num <= 49:
+                    freq[num] += 1
+        top_six = sorted(freq.items(), key=lambda x: (-x[1], x[0]))[:6]
+        numbers = sorted([n for n, _ in top_six])
+        result = "-".join(f"{n:02d}" for n in numbers)
+        self.db.save_predict_nums(
+            last_lotto_date,
+            {"method": "frequency_weighted"},
+            result,
+            source="FREQ",
+        )
+        logger.info(f"Predict numbers: {result}")
+        return result


### PR DESCRIPTION
## Summary
- implement `FrequencyWeightedPredictor` for Lotto 6/49
- add DB helper to return draw numbers from the last two years
- integrate predictor into the main workflow
- document frequency method in README
- default source remains RANDOM; count bonus numbers in DB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*


------
https://chatgpt.com/codex/tasks/task_e_685dd7809e148324a9addec87c9a3b15