### PR TITLE
Add frequency simulation generation

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -14,6 +14,7 @@ from utils.frequency_predict import FrequencyWeightedPredictor
 from utils.collect_history_winner import history_year, current_year
 from utils.custom_db import MyLottoDB
 from utils.purchase_lotto_tickets import do_buying
+from utils.generate_freq_sim_html import main as generate_freq_sim_html
 
 __author__ = '__L1n__w@tch'
 
@@ -91,6 +92,9 @@ def update_html_with_win_status_and_predict_number():
         html = html.replace("{{ matched_distribution_tables }}", "\n".join(matched_distribution_tables))
     with open("docs/index.html", "w") as f:
         f.write(html)
+
+    # also build the frequency-weighted simulation page
+    generate_freq_sim_html()
 
 
 def auto_purchase_lotto(last_lotto_date, number, source="LLM"):

--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -1,0 +1,631 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frequency Weighted Simulation</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        header {
+            background-color: #333;
+            color: white;
+            text-align: center;
+            padding: 1em 0;
+        }
+        main {
+            padding: 20px;
+            overflow-x: auto; /* Enable horizontal scrolling if needed */
+        }
+        table {
+            width: 100%;
+            max-width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+            background: white;
+            display: block;
+            overflow-x: auto;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: center;
+            word-break: break-word;
+        }
+        th {
+            background-color: #333;
+            color: white;
+        }
+        th:nth-child(4), td:nth-child(4) {
+            word-break: break-word;
+        }
+        @media (max-width: 768px) {
+            body {
+                font-size: 14px;
+            }
+            table {
+                font-size: 12px;
+                display: block;
+                overflow-x: auto;
+                white-space: nowrap;
+            }
+            th, td {
+                padding: 5px;
+            }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Frequency Weighted Simulation</h1>
+    <nav>
+        <a href="index.html">Back to Results</a>
+    </nav>
+</header>
+<main>
+    <h2>Summary</h2>
+    <h3>FREQ</h3>
+<table><tr><th>Total Tickets Bought</th><td>100</td></tr><tr><th>Total Win Numbers</th><td>83</td></tr><tr><th>Average Hit Rate</th><td>13.83%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>39</td></tr><tr><td>1</td><td>41</td></tr><tr><td>2</td><td>18</td></tr><tr><td>3</td><td>2</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
+    <h2>Results</h2>
+    <div style="overflow-x: auto;">
+        <table id="resultsTable">
+            <thead>
+            <tr>
+                <th>Last Lotto Date</th>
+                <th>Bought Numbers</th>
+                <th>Win Status</th>
+                <th>LLM Predict Results</th>
+                <th>Predict Number Sources</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td>2024-07-13</td><td>07-10-21-22-25-31</td><td>match 1 number, win number: The Classic Draw
+
+
+05-18-27-31-32-35 Bonus (B):
+(23)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-07-17</td><td>07-10-17-22-25-31</td><td>match 1 number, win number: The Classic Draw
+
+
+11-13-25-28-34-42 Bonus (B):
+(44)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-07-20</td><td>07-10-21-22-25-31</td><td>match 1 number, win number: The Classic Draw
+
+
+05-12-15-23-37-42 Bonus (B):
+(21)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-07-24</td><td>07-10-21-22-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+01-06-34-36-40-48 Bonus (B):
+(27)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-07-27</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+05-23-26-33-36-39 Bonus (B):
+(08)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-07-31</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+12-18-19-26-40-42 Bonus (B):
+(35)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-08-03</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+03-11-18-32-39-42 Bonus (B):
+(28)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-08-07</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+03-06-16-35-41-42 Bonus (B):
+(23)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-08-10</td><td>07-10-22-25-31-41</td><td>match 1 number, win number: The Classic Draw
+
+
+09-15-17-20-25-49 Bonus (B):
+(28)</td><td>07-10-22-25-31-41</td><td>FREQ</td></tr>
+<tr><td>2024-08-14</td><td>07-17-22-25-31-41</td><td>match 0 number, win number: The Classic Draw
+
+
+10-11-29-30-36-48 Bonus (B):
+(18)</td><td>07-17-22-25-31-41</td><td>FREQ</td></tr>
+<tr><td>2024-08-17</td><td>07-10-17-18-22-25</td><td>match 2 number, win number: The Classic Draw
+
+
+07-08-09-10-26-33 Bonus (B):
+(19)</td><td>07-10-17-18-22-25</td><td>FREQ</td></tr>
+<tr><td>2024-08-21</td><td>07-10-17-18-25-41</td><td>match 0 number, win number: The Classic Draw
+
+
+04-06-13-14-34-36 Bonus (B):
+(40)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
+<tr><td>2024-08-24</td><td>07-10-17-18-25-31</td><td>match 0 number, win number: The Classic Draw
+
+
+16-21-29-32-42-49 Bonus (B):
+(05)</td><td>07-10-17-18-25-31</td><td>FREQ</td></tr>
+<tr><td>2024-08-28</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
+
+
+04-20-29-40-41-48 Bonus (B):
+(47)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
+<tr><td>2024-08-31</td><td>07-10-17-18-25-41</td><td>match 2 number, win number: The Classic Draw
+
+
+07-24-25-34-43-44 Bonus (B):
+(13)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
+<tr><td>2024-09-04</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
+
+
+31-34-38-41-43-48 Bonus (B):
+(47)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
+<tr><td>2024-09-07</td><td>07-10-17-25-41-48</td><td>match 0 number, win number: The Classic Draw
+
+
+08-21-33-34-37-47 Bonus (B):
+(24)</td><td>07-10-17-25-41-48</td><td>FREQ</td></tr>
+<tr><td>2024-09-11</td><td>07-10-17-18-25-48</td><td>match 0 number, win number: The Classic Draw
+
+
+01-08-19-33-46-49 Bonus (B):
+(02)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
+<tr><td>2024-09-14</td><td>07-10-17-18-25-48</td><td>match 1 number, win number: The Classic Draw
+
+
+11-14-19-25-26-28 Bonus (B):
+(21)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
+<tr><td>2024-09-18</td><td>07-10-17-18-25-48</td><td>match 1 number, win number: The Classic Draw
+
+
+02-13-14-18-20-39 Bonus (B):
+(40)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
+<tr><td>2024-09-21</td><td>07-10-17-18-25-48</td><td>match 2 number, win number: The Classic Draw
+
+
+05-10-11-15-27-49 Bonus (B):
+(25)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
+<tr><td>2024-09-25</td><td>07-10-17-18-25-42</td><td>match 0 number, win number: The Classic Draw
+
+
+02-04-08-11-14-40 Bonus (B):
+(36)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-09-28</td><td>07-10-17-18-25-42</td><td>match 1 number, win number: The Classic Draw
+
+
+07-15-23-29-41-46 Bonus (B):
+(22)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-10-02</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
+
+
+26-28-33-41-42-49 Bonus (B):
+(45)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
+<tr><td>2024-10-05</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
+
+
+17-18-20-29-32-35 Bonus (B):
+(38)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
+<tr><td>2024-10-09</td><td>07-10-17-18-25-42</td><td>match 1 number, win number: The Classic Draw
+
+
+20-22-23-36-46-47 Bonus (B):
+(42)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-10-12</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
+
+
+03-16-21-28-39-43 Bonus (B):
+(08)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-10-16</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
+
+
+01-17-26-35-44-48 Bonus (B):
+(19)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-10-19</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
+
+
+02-12-20-23-28-41 Bonus (B):
+(43)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-10-23</td><td>07-17-18-25-41-48</td><td>match 1 number, win number: The Classic Draw
+
+
+04-15-18-20-37-40 Bonus (B):
+(43)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
+<tr><td>2024-10-26</td><td>07-17-18-25-41-48</td><td>match 2 number, win number: The Classic Draw
+
+
+07-16-19-25-28-29 Bonus (B):
+(15)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
+<tr><td>2024-10-30</td><td>07-17-18-25-41-48</td><td>match 1 number, win number: The Classic Draw
+
+
+04-09-14-17-30-44 Bonus (B):
+(03)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-02</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
+
+
+07-13-37-42-46-47 Bonus (B):
+(48)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
+<tr><td>2024-11-06</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
+
+
+02-11-18-21-23-25 Bonus (B):
+(26)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
+<tr><td>2024-11-09</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
+
+
+09-12-16-39-47-49 Bonus (B):
+(30)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-13</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
+
+
+05-15-17-29-35-45 Bonus (B):
+(25)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-16</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
+
+
+07-14-21-30-32-42 Bonus (B):
+(15)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-20</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
+
+
+12-13-21-24-46-49 Bonus (B):
+(15)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-23</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
+
+
+03-04-06-11-27-39 Bonus (B):
+(01)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-11-27</td><td>07-17-18-25-27-42</td><td>match 0 number, win number: The Classic Draw
+
+
+02-03-06-14-34-44 Bonus (B):
+(35)</td><td>07-17-18-25-27-42</td><td>FREQ</td></tr>
+<tr><td>2024-11-30</td><td>07-17-18-25-42-48</td><td>match 1 number, win number: The Classic Draw
+
+
+01-05-22-25-36-37 Bonus (B):
+(30)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
+<tr><td>2024-12-04</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
+
+
+19-23-37-39-41-49 Bonus (B):
+(29)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-12-07</td><td>07-17-18-25-29-42</td><td>match 1 number, win number: The Classic Draw
+
+
+09-22-33-41-42-45 Bonus (B):
+(12)</td><td>07-17-18-25-29-42</td><td>FREQ</td></tr>
+<tr><td>2024-12-11</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
+
+
+26-35-39-40-41-46 Bonus (B):
+(03)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-12-14</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
+
+
+03-04-13-16-27-43 Bonus (B):
+(38)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
+<tr><td>2024-12-18</td><td>07-17-18-22-25-27</td><td>match 2 number, win number: The Classic Draw
+
+
+07-09-17-39-41-45 Bonus (B):
+(47)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
+<tr><td>2024-12-21</td><td>07-17-18-22-25-27</td><td>match 0 number, win number: The Classic Draw
+
+
+06-09-21-24-41-48 Bonus (B):
+(31)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
+<tr><td>2024-12-25</td><td>07-17-18-22-25-27</td><td>match 1 number, win number: The Classic Draw
+
+
+05-06-14-16-18-44 Bonus (B):
+(19)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
+<tr><td>2024-12-28</td><td>07-17-18-22-25-27</td><td>match 1 number, win number: The Classic Draw
+
+
+08-16-18-23-34-36 Bonus (B):
+(12)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-01-01</td><td>07-17-18-22-25-27</td><td>match 0 number, win number: The Classic Draw
+
+
+02-10-13-26-35-46 Bonus (B):
+(08)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-01-04</td><td>07-17-18-25-27-41</td><td>match 0 number, win number: The Classic Draw
+
+
+02-05-09-19-24-44 Bonus (B):
+(10)</td><td>07-17-18-25-27-41</td><td>FREQ</td></tr>
+<tr><td>2025-01-08</td><td>07-17-18-25-27-41</td><td>match 0 number, win number: The Classic Draw
+
+
+09-10-12-22-32-34 Bonus (B):
+(47)</td><td>07-17-18-25-27-41</td><td>FREQ</td></tr>
+<tr><td>2025-01-11</td><td>07-17-18-25-27-34</td><td>match 2 number, win number: The Classic Draw
+
+
+03-09-18-25-43-45 Bonus (B):
+(31)</td><td>07-17-18-25-27-34</td><td>FREQ</td></tr>
+<tr><td>2025-01-15</td><td>03-07-17-18-25-27</td><td>match 1 number, win number: The Classic Draw
+
+
+04-17-21-32-33-49 Bonus (B):
+(28)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-01-18</td><td>03-07-17-18-25-27</td><td>match 1 number, win number: The Classic Draw
+
+
+08-13-16-18-31-43 Bonus (B):
+(01)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-01-22</td><td>03-07-17-18-25-43</td><td>match 1 number, win number: The Classic Draw
+
+
+22-24-28-32-41-42 Bonus (B):
+(25)</td><td>03-07-17-18-25-43</td><td>FREQ</td></tr>
+<tr><td>2025-01-25</td><td>03-07-17-18-25-42</td><td>match 0 number, win number: The Classic Draw
+
+
+01-14-19-27-32-40 Bonus (B):
+(37)</td><td>03-07-17-18-25-42</td><td>FREQ</td></tr>
+<tr><td>2025-01-29</td><td>07-17-18-25-27-42</td><td>match 1 number, win number: The Classic Draw
+
+
+03-07-15-20-31-39 Bonus (B):
+(02)</td><td>07-17-18-25-27-42</td><td>FREQ</td></tr>
+<tr><td>2025-02-01</td><td>03-07-17-18-25-27</td><td>match 0 number, win number: The Classic Draw
+
+
+02-28-29-30-36-49 Bonus (B):
+(35)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-02-05</td><td>03-07-17-18-25-27</td><td>match 0 number, win number: The Classic Draw
+
+
+04-13-20-32-37-46 Bonus (B):
+(33)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-02-08</td><td>03-07-17-18-25-27</td><td>match 3 number, win number: The Classic Draw
+
+
+07-17-22-26-27-32 Bonus (B):
+(46)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
+<tr><td>2025-02-12</td><td>03-07-17-18-22-25</td><td>match 0 number, win number: The Classic Draw
+
+
+19-24-39-40-42-45 Bonus (B):
+(41)</td><td>03-07-17-18-22-25</td><td>FREQ</td></tr>
+<tr><td>2025-02-15</td><td>03-07-17-18-22-25</td><td>match 0 number, win number: The Classic Draw
+
+
+08-10-31-37-43-49 Bonus (B):
+(34)</td><td>03-07-17-18-22-25</td><td>FREQ</td></tr>
+<tr><td>2025-02-19</td><td>07-17-18-25-27-34</td><td>match 0 number, win number: The Classic Draw
+
+
+09-10-11-24-31-37 Bonus (B):
+(44)</td><td>07-17-18-25-27-34</td><td>FREQ</td></tr>
+<tr><td>2025-02-22</td><td>07-17-18-22-25-42</td><td>match 1 number, win number: The Classic Draw
+
+
+07-13-29-39-47-48 Bonus (B):
+(26)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
+<tr><td>2025-02-26</td><td>07-17-18-22-25-42</td><td>match 1 number, win number: The Classic Draw
+
+
+07-19-20-26-31-35 Bonus (B):
+(40)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-01</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
+
+
+15-19-25-33-40-42 Bonus (B):
+(13)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-05</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+09-11-26-36-37-42 Bonus (B):
+(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-08</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
+
+
+02-03-13-27-36-48 Bonus (B):
+(15)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-12</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
+
+
+13-15-16-22-23-46 Bonus (B):
+(02)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-15</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+19-31-32-37-38-39 Bonus (B):
+(34)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-19</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
+
+
+06-07-28-32-44-48 Bonus (B):
+(18)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-22</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
+
+
+01-03-13-16-26-32 Bonus (B):
+(21)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-26</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+09-13-25-30-45-49 Bonus (B):
+(08)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-03-29</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+14-23-24-27-34-42 Bonus (B):
+(43)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-02</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+18-26-35-40-43-47 Bonus (B):
+(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-05</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+02-14-23-29-39-42 Bonus (B):
+(15)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-09</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
+
+
+11-18-26-35-37-39 Bonus (B):
+(16)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-12</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
+
+
+17-20-23-36-40-42 Bonus (B):
+(34)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-16</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
+
+
+03-11-13-15-17-39 Bonus (B):
+(32)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-19</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+01-07-31-35-46-49 Bonus (B):
+(29)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-23</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+09-15-22-24-40-49 Bonus (B):
+(25)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-26</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+18-22-28-32-38-44 Bonus (B):
+(20)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-04-30</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+01-09-12-15-34-35 Bonus (B):
+(31)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-03</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+12-22-25-30-36-41 Bonus (B):
+(14)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-07</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
+
+
+01-04-08-13-16-26 Bonus (B):
+(14)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-10</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
+
+
+05-12-17-19-40-47 Bonus (B):
+(29)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-14</td><td>07-17-18-25-26-42</td><td>match 3 number, win number: The Classic Draw
+
+
+01-08-17-18-41-48 Bonus (B):
+(42)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-17</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
+
+
+07-09-20-34-38-46 Bonus (B):
+(14)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-21</td><td>07-17-18-25-26-42</td><td>match 0 number, win number: The Classic Draw
+
+
+01-02-37-38-43-46 Bonus (B):
+(40)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-24</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
+
+
+04-08-18-27-28-31 Bonus (B):
+(48)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-28</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
+
+
+06-13-28-31-34-48 Bonus (B):
+(42)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-05-31</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
+
+
+02-04-11-26-34-37 Bonus (B):
+(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-04</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
+
+
+08-20-30-39-41-48 Bonus (B):
+(18)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-07</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
+
+
+02-10-12-21-36-41 Bonus (B):
+(33)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-11</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+04-09-23-28-32-39 Bonus (B):
+(26)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-14</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
+
+
+05-08-20-28-35-38 Bonus (B):
+(46)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-18</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+08-14-20-25-30-38 Bonus (B):
+(46)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-21</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
+
+
+14-15-17-38-40-49 Bonus (B):
+(23)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+<tr><td>2025-06-25</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
+
+
+04-08-15-20-40-49 Bonus (B):
+(37)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <h2>Hit Rate Over Time</h2>
+    <canvas id="hitRateChart"></canvas>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const rows = document.querySelectorAll('#resultsTable tbody tr');
+            const labels = [];
+            const data = [];
+            rows.forEach(row => {
+                const cells = row.querySelectorAll('td');
+                const date = cells[0].textContent.trim();
+                const winText = cells[2].textContent;
+                const match = winText.match(/match\s+(\d+)/);
+                const count = match ? parseInt(match[1]) : 0;
+                labels.unshift(date);
+                data.unshift(count / 6);
+            });
+            const ctx = document.getElementById('hitRateChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Hit Rate',
+                        data: data,
+                        borderColor: 'blue',
+                        fill: false
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {beginAtZero: true, max: 1}
+                    }
+                }
+            });
+        });
+    </script>
+</main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,6 +62,9 @@
 <body>
 <header>
     <h1>Historical Lotto Results</h1>
+    <nav>
+        <a href="freq_simulation.html">Frequency Simulation</a>
+    </nav>
 </header>
 <main>
     <h2>Summary</h2>

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -62,6 +62,9 @@
 <body>
 <header>
     <h1>Historical Lotto Results</h1>
+    <nav>
+        <a href="freq_simulation.html">Frequency Simulation</a>
+    </nav>
 </header>
 <main>
     <h2>Summary</h2>

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate frequency-weighted simulation HTML."""
+
+import sqlite3
+import json
+import re
+import datetime
+import os
+from utils.common import root
+from utils.frequency_predict import FrequencyWeightedPredictor
+
+
+def parse_numbers(data_str):
+    data = json.loads(data_str)
+    if '0' in data:
+        text = data['0']
+    else:
+        first = next(iter(data.values()))
+        if isinstance(first, list):
+            first = ' '.join(first[0]) if isinstance(first[0], list) else ' '.join(first)
+        text = str(first)
+    numbers = [int(n) for n in re.findall(r"\d+", text)[:7]]
+    return numbers, text
+
+
+def get_past_numbers(cur, start_val, end_val):
+    cur.execute(
+        "SELECT data FROM history_lotto WHERE (year*10000+month*100+day) >= ? AND (year*10000+month*100+day) < ?",
+        (start_val, end_val),
+    )
+    rows = [r[0] for r in cur.fetchall()]
+    numbers = []
+    for r in rows:
+        nums, _ = parse_numbers(r)
+        numbers.append(nums)
+    return numbers
+
+
+def freq_predict(cur, predictor, current_date):
+    """Return predicted numbers for the given date using the existing predictor."""
+    start_date = current_date - datetime.timedelta(days=365 * 2)
+    start_val = start_date.year * 10000 + start_date.month * 100 + start_date.day
+    end_val = current_date.year * 10000 + current_date.month * 100 + current_date.day
+    past_draws = get_past_numbers(cur, start_val, end_val)
+
+    # Temporarily override the predictor's data source
+    original_get_recent = predictor._get_recent_numbers
+    predictor._get_recent_numbers = lambda: past_draws
+    result_str = predictor.predict(current_date.strftime("%Y-%m-%d"))
+    predictor._get_recent_numbers = original_get_recent
+
+    numbers = [int(n) for n in result_str.split("-")]
+    return numbers
+
+
+def main():
+    db_path = os.path.join(root, 'data', 'lotto.db')
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute('SELECT year, month, day, data FROM history_lotto ORDER BY year DESC, month DESC, day DESC LIMIT 100')
+    rows = cur.fetchall()[::-1]  # reverse to chronological order
+
+    result_rows = []
+    total_win_numbers = 0
+    distribution = {i: 0 for i in range(7)}
+
+    predictor = FrequencyWeightedPredictor()
+    predictor.db.save_predict_nums = lambda *args, **kwargs: None
+
+    for year, month, day, data in rows:
+        current_date = datetime.date(year, month, day)
+        predicted_nums = freq_predict(cur, predictor, current_date)
+        predicted_str = '-'.join(f"{n:02d}" for n in predicted_nums)
+        actual_nums, actual_str = parse_numbers(data)
+        match_count = sum(1 for n in predicted_nums if n in actual_nums)
+        total_win_numbers += match_count
+        if match_count in distribution:
+            distribution[match_count] += 1
+        date_str = f"{year}-{month:02d}-{day:02d}"
+        win_status = f"match {match_count} number, win number: {actual_str}"
+        row_html = '<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>FREQ</td></tr>'.format(
+            date_str, predicted_str, win_status, predicted_str
+        )
+        result_rows.append(row_html)
+
+    total_tickets = len(result_rows)
+    avg_hit_rate = total_win_numbers / (total_tickets * 6) if total_tickets else 0
+
+    summary_html = ["<h3>FREQ</h3>"]
+    summary_html.append(
+        f"<table><tr><th>Total Tickets Bought</th><td>{total_tickets}</td></tr>"
+        f"<tr><th>Total Win Numbers</th><td>{total_win_numbers}</td></tr>"
+        f"<tr><th>Average Hit Rate</th><td>{avg_hit_rate:.2%}</td></tr></table>"
+    )
+
+    distribution_rows = []
+    for i in range(7):
+        distribution_rows.append(f"<tr><td>{i}</td><td>{distribution[i]}</td></tr>")
+    distribution_html = ["<h3>FREQ</h3>"]
+    distribution_html.append(
+        "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody>"
+        + ''.join(distribution_rows) + "</tbody></table>"
+    )
+
+    template_path = os.path.join(root, 'docs', 'index_template.html')
+    with open(template_path, 'r') as f:
+        html = f.read()
+    html = html.replace('Historical Lotto Results', 'Frequency Weighted Simulation')
+    html = html.replace('href="freq_simulation.html"', 'href="index.html"')
+    html = html.replace('Frequency Simulation', 'Back to Results')
+    html = html.replace('{{ summary_tables }}', '\n'.join(summary_html))
+    html = html.replace('{{ matched_distribution_tables }}', '\n'.join(distribution_html))
+    html = html.replace('{{ need_to_be_replaced }}', '\n'.join(result_rows))
+
+    out_path = os.path.join(root, 'docs', 'freq_simulation.html')
+    with open(out_path, 'w') as f:
+        f.write(html)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- reuse `FrequencyWeightedPredictor` in `generate_freq_sim_html.py`
- build frequency simulation page when updating results
- prevent DB writes during simulation

## Testing
- `PYTHONPATH=. python3 utils/generate_freq_sim_html.py`


------
https://chatgpt.com/codex/tasks/task_e_685ddba9822c8324a3c652e543cf71d8