### PR TITLE
Fix frequency predictor date handling

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -148,7 +148,8 @@ def predict_next_lotto(last_lotto_date, source="LLM"):
         return generator.predict(last_lotto_date)
     if source.upper() == "FREQ":
         generator = FrequencyWeightedPredictor()
-        return generator.predict(last_lotto_date)
+        reference_date = datetime.datetime.strptime(last_lotto_date, "%Y-%m-%d").date()
+        return generator.predict(reference_date)
 
     llm = LargeLanguageModel(model="openai")
     recent_win = MY_DB.get_recent_lotto_win_numbers()

--- a/utils/frequency_predict.py
+++ b/utils/frequency_predict.py
@@ -12,14 +12,25 @@ class FrequencyWeightedPredictor:
     def __init__(self):
         self.db = MyLottoDB()
 
-    def _get_recent_numbers(self):
-        """Return lists of lotto numbers from the last two years."""
-        end = datetime.datetime.now()
-        start = end - datetime.timedelta(days=365 * 2)
+    def _get_recent_numbers(self, reference_date=None):
+        """Return lists of lotto numbers from the two years prior to `reference_date`."""
+        if reference_date is None:
+            reference_date = datetime.datetime.now()
+        if isinstance(reference_date, datetime.date) and not isinstance(reference_date, datetime.datetime):
+            reference_date = datetime.datetime.combine(reference_date, datetime.time.min)
+        start = reference_date - datetime.timedelta(days=365 * 2)
         return self.db.get_lotto_numbers_since(start)
 
     def predict(self, last_lotto_date):
-        draws = self._get_recent_numbers()
+        if isinstance(last_lotto_date, (datetime.date, datetime.datetime)):
+            reference_date = (last_lotto_date if isinstance(last_lotto_date, datetime.datetime)
+                             else datetime.datetime.combine(last_lotto_date, datetime.time.min))
+            last_lotto_date_str = last_lotto_date.strftime("%Y-%m-%d")
+        else:
+            reference_date = datetime.datetime.strptime(last_lotto_date, "%Y-%m-%d")
+            last_lotto_date_str = last_lotto_date
+
+        draws = self._get_recent_numbers(reference_date=reference_date)
         freq = {i: 0 for i in range(1, 50)}
         for draw in draws:
             for num in draw:
@@ -29,7 +40,7 @@ class FrequencyWeightedPredictor:
         numbers = sorted([n for n, _ in top_six])
         result = "-".join(f"{n:02d}" for n in numbers)
         self.db.save_predict_nums(
-            last_lotto_date,
+            last_lotto_date_str,
             {"method": "frequency_weighted"},
             result,
             source="FREQ",

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -46,8 +46,8 @@ def freq_predict(cur, predictor, current_date):
 
     # Temporarily override the predictor's data source
     original_get_recent = predictor._get_recent_numbers
-    predictor._get_recent_numbers = lambda: past_draws
-    result_str = predictor.predict(current_date.strftime("%Y-%m-%d"))
+    predictor._get_recent_numbers = lambda reference_date=None: past_draws
+    result_str = predictor.predict(current_date)
     predictor._get_recent_numbers = original_get_recent
 
     numbers = [int(n) for n in result_str.split("-")]


### PR DESCRIPTION
## Summary
- support using prediction date for frequency window in predictor
- parse dates in `predict_next_lotto`
- update simulation code to use the passed date

## Testing
- `python -m py_compile utils/frequency_predict.py auto_lotto_main.py utils/generate_freq_sim_html.py`


------
https://chatgpt.com/codex/tasks/task_e_685de5544500832497a7b65153fcfdfc