### PR TITLE
Fix header link contrast and align freq sim data

### DIFF
--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -17,6 +17,10 @@
             text-align: center;
             padding: 1em 0;
         }
+        header nav a {
+            color: #fff;
+            text-decoration: underline;
+        }
         main {
             padding: 20px;
             overflow-x: auto; /* Enable horizontal scrolling if needed */
@@ -69,10 +73,10 @@
 <main>
     <h2>Summary</h2>
     <h3>FREQ</h3>
-<table><tr><th>Total Tickets Bought</th><td>100</td></tr><tr><th>Total Win Numbers</th><td>83</td></tr><tr><th>Average Hit Rate</th><td>13.83%</td></tr></table>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>33</td></tr><tr><th>Average Hit Rate</th><td>12.50%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>39</td></tr><tr><td>1</td><td>41</td></tr><tr><td>2</td><td>18</td></tr><tr><td>3</td><td>2</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>21</td></tr><tr><td>1</td><td>15</td></tr><tr><td>2</td><td>6</td></tr><tr><td>3</td><td>2</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">
@@ -86,506 +90,50 @@
             </tr>
             </thead>
             <tbody>
-            <tr><td>2024-07-13</td><td>07-10-21-22-25-31</td><td>match 1 number, win number: The Classic Draw
-
-
-05-18-27-31-32-35 Bonus (B):
-(23)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-07-17</td><td>07-10-17-22-25-31</td><td>match 1 number, win number: The Classic Draw
-
-
-11-13-25-28-34-42 Bonus (B):
-(44)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-07-20</td><td>07-10-21-22-25-31</td><td>match 1 number, win number: The Classic Draw
-
-
-05-12-15-23-37-42 Bonus (B):
-(21)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-07-24</td><td>07-10-21-22-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-01-06-34-36-40-48 Bonus (B):
-(27)</td><td>07-10-21-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-07-27</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-05-23-26-33-36-39 Bonus (B):
-(08)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-07-31</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-12-18-19-26-40-42 Bonus (B):
-(35)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-08-03</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-03-11-18-32-39-42 Bonus (B):
-(28)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-08-07</td><td>07-10-17-22-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-03-06-16-35-41-42 Bonus (B):
-(23)</td><td>07-10-17-22-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-08-10</td><td>07-10-22-25-31-41</td><td>match 1 number, win number: The Classic Draw
-
-
-09-15-17-20-25-49 Bonus (B):
-(28)</td><td>07-10-22-25-31-41</td><td>FREQ</td></tr>
-<tr><td>2024-08-14</td><td>07-17-22-25-31-41</td><td>match 0 number, win number: The Classic Draw
-
-
-10-11-29-30-36-48 Bonus (B):
-(18)</td><td>07-17-22-25-31-41</td><td>FREQ</td></tr>
-<tr><td>2024-08-17</td><td>07-10-17-18-22-25</td><td>match 2 number, win number: The Classic Draw
-
-
-07-08-09-10-26-33 Bonus (B):
-(19)</td><td>07-10-17-18-22-25</td><td>FREQ</td></tr>
-<tr><td>2024-08-21</td><td>07-10-17-18-25-41</td><td>match 0 number, win number: The Classic Draw
-
-
-04-06-13-14-34-36 Bonus (B):
-(40)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
-<tr><td>2024-08-24</td><td>07-10-17-18-25-31</td><td>match 0 number, win number: The Classic Draw
-
-
-16-21-29-32-42-49 Bonus (B):
-(05)</td><td>07-10-17-18-25-31</td><td>FREQ</td></tr>
-<tr><td>2024-08-28</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
-
-
-04-20-29-40-41-48 Bonus (B):
-(47)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
-<tr><td>2024-08-31</td><td>07-10-17-18-25-41</td><td>match 2 number, win number: The Classic Draw
-
-
-07-24-25-34-43-44 Bonus (B):
-(13)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
-<tr><td>2024-09-04</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
-
-
-31-34-38-41-43-48 Bonus (B):
-(47)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
-<tr><td>2024-09-07</td><td>07-10-17-25-41-48</td><td>match 0 number, win number: The Classic Draw
-
-
-08-21-33-34-37-47 Bonus (B):
-(24)</td><td>07-10-17-25-41-48</td><td>FREQ</td></tr>
-<tr><td>2024-09-11</td><td>07-10-17-18-25-48</td><td>match 0 number, win number: The Classic Draw
-
-
-01-08-19-33-46-49 Bonus (B):
-(02)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
-<tr><td>2024-09-14</td><td>07-10-17-18-25-48</td><td>match 1 number, win number: The Classic Draw
-
-
-11-14-19-25-26-28 Bonus (B):
-(21)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
-<tr><td>2024-09-18</td><td>07-10-17-18-25-48</td><td>match 1 number, win number: The Classic Draw
-
-
-02-13-14-18-20-39 Bonus (B):
-(40)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
-<tr><td>2024-09-21</td><td>07-10-17-18-25-48</td><td>match 2 number, win number: The Classic Draw
-
-
-05-10-11-15-27-49 Bonus (B):
-(25)</td><td>07-10-17-18-25-48</td><td>FREQ</td></tr>
-<tr><td>2024-09-25</td><td>07-10-17-18-25-42</td><td>match 0 number, win number: The Classic Draw
-
-
-02-04-08-11-14-40 Bonus (B):
-(36)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-09-28</td><td>07-10-17-18-25-42</td><td>match 1 number, win number: The Classic Draw
-
-
-07-15-23-29-41-46 Bonus (B):
-(22)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-10-02</td><td>07-10-17-18-25-41</td><td>match 1 number, win number: The Classic Draw
-
-
-26-28-33-41-42-49 Bonus (B):
-(45)</td><td>07-10-17-18-25-41</td><td>FREQ</td></tr>
-<tr><td>2024-10-05</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
-
-
-17-18-20-29-32-35 Bonus (B):
-(38)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
-<tr><td>2024-10-09</td><td>07-10-17-18-25-42</td><td>match 1 number, win number: The Classic Draw
-
-
-20-22-23-36-46-47 Bonus (B):
-(42)</td><td>07-10-17-18-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-10-12</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
-
-
-03-16-21-28-39-43 Bonus (B):
-(08)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-10-16</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
-
-
-01-17-26-35-44-48 Bonus (B):
-(19)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-10-19</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
-
-
-02-12-20-23-28-41 Bonus (B):
-(43)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-10-23</td><td>07-17-18-25-41-48</td><td>match 1 number, win number: The Classic Draw
-
-
-04-15-18-20-37-40 Bonus (B):
-(43)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
-<tr><td>2024-10-26</td><td>07-17-18-25-41-48</td><td>match 2 number, win number: The Classic Draw
-
-
-07-16-19-25-28-29 Bonus (B):
-(15)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
-<tr><td>2024-10-30</td><td>07-17-18-25-41-48</td><td>match 1 number, win number: The Classic Draw
-
-
-04-09-14-17-30-44 Bonus (B):
-(03)</td><td>07-17-18-25-41-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-02</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
-
-
-07-13-37-42-46-47 Bonus (B):
-(48)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
-<tr><td>2024-11-06</td><td>07-17-18-25-41-42</td><td>match 2 number, win number: The Classic Draw
-
-
-02-11-18-21-23-25 Bonus (B):
-(26)</td><td>07-17-18-25-41-42</td><td>FREQ</td></tr>
-<tr><td>2024-11-09</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
-
-
-09-12-16-39-47-49 Bonus (B):
-(30)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-13</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
-
-
-05-15-17-29-35-45 Bonus (B):
-(25)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-16</td><td>07-17-18-25-42-48</td><td>match 2 number, win number: The Classic Draw
-
-
-07-14-21-30-32-42 Bonus (B):
-(15)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-20</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
-
-
-12-13-21-24-46-49 Bonus (B):
-(15)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-23</td><td>07-17-18-25-42-48</td><td>match 0 number, win number: The Classic Draw
-
-
-03-04-06-11-27-39 Bonus (B):
-(01)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-11-27</td><td>07-17-18-25-27-42</td><td>match 0 number, win number: The Classic Draw
-
-
-02-03-06-14-34-44 Bonus (B):
-(35)</td><td>07-17-18-25-27-42</td><td>FREQ</td></tr>
-<tr><td>2024-11-30</td><td>07-17-18-25-42-48</td><td>match 1 number, win number: The Classic Draw
-
-
-01-05-22-25-36-37 Bonus (B):
-(30)</td><td>07-17-18-25-42-48</td><td>FREQ</td></tr>
-<tr><td>2024-12-04</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
-
-
-19-23-37-39-41-49 Bonus (B):
-(29)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-12-07</td><td>07-17-18-25-29-42</td><td>match 1 number, win number: The Classic Draw
-
-
-09-22-33-41-42-45 Bonus (B):
-(12)</td><td>07-17-18-25-29-42</td><td>FREQ</td></tr>
-<tr><td>2024-12-11</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
-
-
-26-35-39-40-41-46 Bonus (B):
-(03)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-12-14</td><td>07-17-18-22-25-42</td><td>match 0 number, win number: The Classic Draw
-
-
-03-04-13-16-27-43 Bonus (B):
-(38)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
-<tr><td>2024-12-18</td><td>07-17-18-22-25-27</td><td>match 2 number, win number: The Classic Draw
-
-
-07-09-17-39-41-45 Bonus (B):
-(47)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
-<tr><td>2024-12-21</td><td>07-17-18-22-25-27</td><td>match 0 number, win number: The Classic Draw
-
-
-06-09-21-24-41-48 Bonus (B):
-(31)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
-<tr><td>2024-12-25</td><td>07-17-18-22-25-27</td><td>match 1 number, win number: The Classic Draw
-
-
-05-06-14-16-18-44 Bonus (B):
-(19)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
-<tr><td>2024-12-28</td><td>07-17-18-22-25-27</td><td>match 1 number, win number: The Classic Draw
-
-
-08-16-18-23-34-36 Bonus (B):
-(12)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-01-01</td><td>07-17-18-22-25-27</td><td>match 0 number, win number: The Classic Draw
-
-
-02-10-13-26-35-46 Bonus (B):
-(08)</td><td>07-17-18-22-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-01-04</td><td>07-17-18-25-27-41</td><td>match 0 number, win number: The Classic Draw
-
-
-02-05-09-19-24-44 Bonus (B):
-(10)</td><td>07-17-18-25-27-41</td><td>FREQ</td></tr>
-<tr><td>2025-01-08</td><td>07-17-18-25-27-41</td><td>match 0 number, win number: The Classic Draw
-
-
-09-10-12-22-32-34 Bonus (B):
-(47)</td><td>07-17-18-25-27-41</td><td>FREQ</td></tr>
-<tr><td>2025-01-11</td><td>07-17-18-25-27-34</td><td>match 2 number, win number: The Classic Draw
-
-
-03-09-18-25-43-45 Bonus (B):
-(31)</td><td>07-17-18-25-27-34</td><td>FREQ</td></tr>
-<tr><td>2025-01-15</td><td>03-07-17-18-25-27</td><td>match 1 number, win number: The Classic Draw
-
-
-04-17-21-32-33-49 Bonus (B):
-(28)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-01-18</td><td>03-07-17-18-25-27</td><td>match 1 number, win number: The Classic Draw
-
-
-08-13-16-18-31-43 Bonus (B):
-(01)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-01-22</td><td>03-07-17-18-25-43</td><td>match 1 number, win number: The Classic Draw
-
-
-22-24-28-32-41-42 Bonus (B):
-(25)</td><td>03-07-17-18-25-43</td><td>FREQ</td></tr>
-<tr><td>2025-01-25</td><td>03-07-17-18-25-42</td><td>match 0 number, win number: The Classic Draw
-
-
-01-14-19-27-32-40 Bonus (B):
-(37)</td><td>03-07-17-18-25-42</td><td>FREQ</td></tr>
-<tr><td>2025-01-29</td><td>07-17-18-25-27-42</td><td>match 1 number, win number: The Classic Draw
-
-
-03-07-15-20-31-39 Bonus (B):
-(02)</td><td>07-17-18-25-27-42</td><td>FREQ</td></tr>
-<tr><td>2025-02-01</td><td>03-07-17-18-25-27</td><td>match 0 number, win number: The Classic Draw
-
-
-02-28-29-30-36-49 Bonus (B):
-(35)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-02-05</td><td>03-07-17-18-25-27</td><td>match 0 number, win number: The Classic Draw
-
-
-04-13-20-32-37-46 Bonus (B):
-(33)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-02-08</td><td>03-07-17-18-25-27</td><td>match 3 number, win number: The Classic Draw
-
-
-07-17-22-26-27-32 Bonus (B):
-(46)</td><td>03-07-17-18-25-27</td><td>FREQ</td></tr>
-<tr><td>2025-02-12</td><td>03-07-17-18-22-25</td><td>match 0 number, win number: The Classic Draw
-
-
-19-24-39-40-42-45 Bonus (B):
-(41)</td><td>03-07-17-18-22-25</td><td>FREQ</td></tr>
-<tr><td>2025-02-15</td><td>03-07-17-18-22-25</td><td>match 0 number, win number: The Classic Draw
-
-
-08-10-31-37-43-49 Bonus (B):
-(34)</td><td>03-07-17-18-22-25</td><td>FREQ</td></tr>
-<tr><td>2025-02-19</td><td>07-17-18-25-27-34</td><td>match 0 number, win number: The Classic Draw
-
-
-09-10-11-24-31-37 Bonus (B):
-(44)</td><td>07-17-18-25-27-34</td><td>FREQ</td></tr>
-<tr><td>2025-02-22</td><td>07-17-18-22-25-42</td><td>match 1 number, win number: The Classic Draw
-
-
-07-13-29-39-47-48 Bonus (B):
-(26)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
-<tr><td>2025-02-26</td><td>07-17-18-22-25-42</td><td>match 1 number, win number: The Classic Draw
-
-
-07-19-20-26-31-35 Bonus (B):
-(40)</td><td>07-17-18-22-25-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-01</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
-
-
-15-19-25-33-40-42 Bonus (B):
-(13)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-05</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-09-11-26-36-37-42 Bonus (B):
-(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-08</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
-
-
-02-03-13-27-36-48 Bonus (B):
-(15)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-12</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
-
-
-13-15-16-22-23-46 Bonus (B):
-(02)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-15</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-19-31-32-37-38-39 Bonus (B):
-(34)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-19</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
-
-
-06-07-28-32-44-48 Bonus (B):
-(18)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-22</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
-
-
-01-03-13-16-26-32 Bonus (B):
-(21)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-26</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-09-13-25-30-45-49 Bonus (B):
-(08)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-03-29</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-14-23-24-27-34-42 Bonus (B):
-(43)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-02</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-18-26-35-40-43-47 Bonus (B):
-(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-05</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-02-14-23-29-39-42 Bonus (B):
-(15)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-09</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
-
-
-11-18-26-35-37-39 Bonus (B):
-(16)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-12</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
-
-
-17-20-23-36-40-42 Bonus (B):
-(34)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-16</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw
-
-
-03-11-13-15-17-39 Bonus (B):
-(32)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-19</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-01-07-31-35-46-49 Bonus (B):
-(29)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-23</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-09-15-22-24-40-49 Bonus (B):
-(25)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-26</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-18-22-28-32-38-44 Bonus (B):
-(20)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-04-30</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-01-09-12-15-34-35 Bonus (B):
-(31)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-03</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-12-22-25-30-36-41 Bonus (B):
-(14)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-07</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
-
-
-01-04-08-13-16-26 Bonus (B):
-(14)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-10</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw
-
-
-05-12-17-19-40-47 Bonus (B):
-(29)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-14</td><td>07-17-18-25-26-42</td><td>match 3 number, win number: The Classic Draw
-
-
-01-08-17-18-41-48 Bonus (B):
-(42)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-17</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
-
-
-07-09-20-34-38-46 Bonus (B):
-(14)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-21</td><td>07-17-18-25-26-42</td><td>match 0 number, win number: The Classic Draw
-
-
-01-02-37-38-43-46 Bonus (B):
-(40)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-24</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
-
-
-04-08-18-27-28-31 Bonus (B):
-(48)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-28</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw
-
-
-06-13-28-31-34-48 Bonus (B):
-(42)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-05-31</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw
-
-
-02-04-11-26-34-37 Bonus (B):
-(24)</td><td>07-17-18-25-31-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-04</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw
-
-
-08-20-30-39-41-48 Bonus (B):
-(18)</td><td>07-17-18-25-26-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-07</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
-
-
-02-10-12-21-36-41 Bonus (B):
-(33)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-11</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-04-09-23-28-32-39 Bonus (B):
-(26)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-14</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
-
-
-05-08-20-28-35-38 Bonus (B):
-(46)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-18</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-08-14-20-25-30-38 Bonus (B):
-(46)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-21</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw
-
-
-14-15-17-38-40-49 Bonus (B):
-(23)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
-<tr><td>2025-06-25</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw
-
-
-04-08-15-20-40-49 Bonus (B):
-(37)</td><td>07-17-18-25-39-42</td><td>FREQ</td></tr>
+            <tr><td>2025-01-25</td><td>07-08-17-18-20-25</td><td>match 0 number, win number: The Classic Draw 01-14-19-27-32-40 Bonus (B): (37)</td><td>07-08-17-18-20-25</td><td>FREQ</td></tr>
+<tr><td>2025-01-29</td><td>01-14-19-27-32-37</td><td>match 0 number, win number: The Classic Draw 03-07-15-20-31-39 Bonus (B): (02)</td><td>01-14-19-27-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-01</td><td>01-02-03-07-14-15</td><td>match 1 number, win number: The Classic Draw 02-28-29-30-36-49 Bonus (B): (35)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
+<tr><td>2025-02-05</td><td>01-02-03-07-14-15</td><td>match 0 number, win number: The Classic Draw 04-13-20-32-37-46 Bonus (B): (33)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
+<tr><td>2025-02-08</td><td>01-02-03-20-32-37</td><td>match 1 number, win number: The Classic Draw 07-17-22-26-27-32 Bonus (B): (46)</td><td>01-02-03-20-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-12</td><td>02-07-20-27-32-37</td><td>match 0 number, win number: The Classic Draw 19-24-39-40-42-45 Bonus (B): (41)</td><td>02-07-20-27-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-15</td><td>02-07-19-20-27-32</td><td>match 0 number, win number: The Classic Draw 08-10-31-37-43-49 Bonus (B): (34)</td><td>02-07-19-20-27-32</td><td>FREQ</td></tr>
+<tr><td>2025-02-19</td><td>02-07-19-20-32-37</td><td>match 1 number, win number: The Classic Draw 09-10-11-24-31-37 Bonus (B): (44)</td><td>02-07-19-20-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-22</td><td>02-07-10-31-32-37</td><td>match 1 number, win number: The Classic Draw 07-13-29-39-47-48 Bonus (B): (26)</td><td>02-07-10-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-26</td><td>02-07-31-32-37-39</td><td>match 2 number, win number: The Classic Draw 07-19-20-26-31-35 Bonus (B): (40)</td><td>02-07-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-03-01</td><td>07-19-20-26-31-37</td><td>match 1 number, win number: The Classic Draw 15-19-25-33-40-42 Bonus (B): (13)</td><td>07-19-20-26-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-05</td><td>07-13-19-31-37-40</td><td>match 1 number, win number: The Classic Draw 09-11-26-36-37-42 Bonus (B): (24)</td><td>07-13-19-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-03-08</td><td>07-19-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-03-13-27-36-48 Bonus (B): (15)</td><td>07-19-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-03-12</td><td>07-13-19-26-31-37</td><td>match 1 number, win number: The Classic Draw 13-15-16-22-23-46 Bonus (B): (02)</td><td>07-13-19-26-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-15</td><td>02-07-13-15-19-37</td><td>match 2 number, win number: The Classic Draw 19-31-32-37-38-39 Bonus (B): (34)</td><td>02-07-13-15-19-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-19</td><td>02-07-13-19-31-37</td><td>match 1 number, win number: The Classic Draw 06-07-28-32-44-48 Bonus (B): (18)</td><td>02-07-13-19-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-22</td><td>07-13-19-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-03-13-16-26-32 Bonus (B): (21)</td><td>07-13-19-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-26</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 09-13-25-30-45-49 Bonus (B): (08)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-29</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 14-23-24-27-34-42 Bonus (B): (43)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-02</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 18-26-35-40-43-47 Bonus (B): (24)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-05</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 02-14-23-29-39-42 Bonus (B): (15)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-09</td><td>02-07-13-26-32-37</td><td>match 2 number, win number: The Classic Draw 11-18-26-35-37-39 Bonus (B): (16)</td><td>02-07-13-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-12</td><td>02-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 17-20-23-36-40-42 Bonus (B): (34)</td><td>02-13-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-16</td><td>13-26-32-37-39-40</td><td>match 3 number, win number: The Classic Draw 03-11-13-15-17-39 Bonus (B): (32)</td><td>13-26-32-37-39-40</td><td>FREQ</td></tr>
+<tr><td>2025-04-19</td><td>13-15-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 01-07-31-35-46-49 Bonus (B): (29)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-23</td><td>07-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 09-15-22-24-40-49 Bonus (B): (25)</td><td>07-13-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-26</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 18-22-28-32-38-44 Bonus (B): (20)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-30</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 01-09-12-15-34-35 Bonus (B): (31)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-05-03</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 12-22-25-30-36-41 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-05-07</td><td>13-15-26-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-04-08-13-16-26 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-05-10</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 05-12-17-19-40-47 Bonus (B): (29)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-05-14</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 01-08-17-18-41-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-17</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 07-09-20-34-38-46 Bonus (B): (14)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-21</td><td>07-13-15-26-32-40</td><td>match 1 number, win number: The Classic Draw 01-02-37-38-43-46 Bonus (B): (40)</td><td>07-13-15-26-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-24</td><td>13-15-26-32-37-40</td><td>match 0 number, win number: The Classic Draw 04-08-18-27-28-31 Bonus (B): (48)</td><td>13-15-26-32-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-28</td><td>13-15-26-31-32-40</td><td>match 2 number, win number: The Classic Draw 06-13-28-31-34-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-31</td><td>13-15-26-31-32-40</td><td>match 1 number, win number: The Classic Draw 02-04-11-26-34-37 Bonus (B): (24)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-04</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 08-20-30-39-41-48 Bonus (B): (18)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-07</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-10-12-21-36-41 Bonus (B): (33)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-11</td><td>02-13-26-31-37-40</td><td>match 1 number, win number: The Classic Draw 04-09-23-28-32-39 Bonus (B): (26)</td><td>02-13-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-14</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 05-08-20-28-35-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-06-18</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 08-14-20-25-30-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-06-21</td><td>13-20-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 14-15-17-38-40-49 Bonus (B): (23)</td><td>13-20-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-06-25</td><td>13-15-20-26-31-40</td><td>match 3 number, win number: The Classic Draw 04-08-15-20-40-49 Bonus (B): (37)</td><td>13-15-20-26-31-40</td><td>FREQ</td></tr>
             </tbody>
         </table>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,10 @@
             text-align: center;
             padding: 1em 0;
         }
+        header nav a {
+            color: #fff;
+            text-decoration: underline;
+        }
         main {
             padding: 20px;
             overflow-x: auto; /* Enable horizontal scrolling if needed */

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -17,6 +17,10 @@
             text-align: center;
             padding: 1em 0;
         }
+        header nav a {
+            color: #fff;
+            text-decoration: underline;
+        }
         main {
             padding: 20px;
             overflow-x: auto; /* Enable horizontal scrolling if needed */

--- a/utils/frequency_predict.py
+++ b/utils/frequency_predict.py
@@ -9,17 +9,27 @@ from utils.custom_db import MyLottoDB
 class FrequencyWeightedPredictor:
     """Predict lotto numbers using frequency analysis of past draws."""
 
-    def __init__(self):
+    def __init__(self, *, min_start_date=None):
         self.db = MyLottoDB()
+        # Ignore draws earlier than this date when building the
+        # frequency table. Defaults to the first draw of the new
+        # method on 2025‑01‑25.
+        self.min_start_date = min_start_date or datetime.date(2025, 1, 25)
 
     def _get_recent_numbers(self):
         """Return lists of lotto numbers from the last two years."""
         end = datetime.datetime.now()
         start = end - datetime.timedelta(days=365 * 2)
-        return self.db.get_lotto_numbers_since(start)
+        start_date = max(start.date(), self.min_start_date)
+        return self.db.get_lotto_numbers_since(start_date)
 
     def predict(self, last_lotto_date):
         draws = self._get_recent_numbers()
+        if not draws:
+            # Fall back to using all available draws so that a
+            # reasonable prediction is returned even for an empty
+            # recent history window.
+            draws = self.db.get_lotto_numbers_since(self.min_start_date)
         freq = {i: 0 for i in range(1, 50)}
         for draw in draws:
             for num in draw:

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -20,6 +20,7 @@ def parse_numbers(data_str):
         if isinstance(first, list):
             first = ' '.join(first[0]) if isinstance(first[0], list) else ' '.join(first)
         text = str(first)
+    text = re.sub(r"\s+", " ", text.strip())
     numbers = [int(n) for n in re.findall(r"\d+", text)[:7]]
     return numbers, text
 
@@ -38,13 +39,27 @@ def get_past_numbers(cur, start_val, end_val):
 
 
 def freq_predict(cur, predictor, current_date):
-    """Return predicted numbers for the given date using the existing predictor."""
-    start_date = current_date - datetime.timedelta(days=365 * 2)
+    """Return predicted numbers for the given date using the existing predictor.
+
+    Only draws on or after 2025-01-25 are considered when building the
+    frequency table.
+    """
+    min_start = datetime.date(2025, 1, 25)
+    start_date = max(min_start, current_date - datetime.timedelta(days=365 * 2))
     start_val = start_date.year * 10000 + start_date.month * 100 + start_date.day
     end_val = current_date.year * 10000 + current_date.month * 100 + current_date.day
     past_draws = get_past_numbers(cur, start_val, end_val)
 
-    # Temporarily override the predictor's data source
+    # When there are no prior draws in the limited range, fall back to the
+    # predictor's default behaviour (which uses a wider history window). This
+    # avoids returning the trivial sequence ``1-2-3-4-5-6`` which happens when
+    # all frequencies are zero.
+    if not past_draws:
+        result_str = predictor.predict(current_date.strftime("%Y-%m-%d"))
+        return [int(n) for n in result_str.split("-")]
+
+    # Temporarily override the predictor's data source with draws from our
+    # restricted range.
     original_get_recent = predictor._get_recent_numbers
     predictor._get_recent_numbers = lambda: past_draws
     result_str = predictor.predict(current_date.strftime("%Y-%m-%d"))
@@ -58,8 +73,14 @@ def main():
     db_path = os.path.join(root, 'data', 'lotto.db')
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
-    cur.execute('SELECT year, month, day, data FROM history_lotto ORDER BY year DESC, month DESC, day DESC LIMIT 100')
-    rows = cur.fetchall()[::-1]  # reverse to chronological order
+    start_val = 20250125
+    cur.execute(
+        'SELECT year, month, day, data FROM history_lotto '
+        'WHERE (year * 10000 + month * 100 + day) >= ? '
+        'ORDER BY year ASC, month ASC, day ASC',
+        (start_val,)
+    )
+    rows = cur.fetchall()
 
     result_rows = []
     total_win_numbers = 0


### PR DESCRIPTION
## Summary
- improve nav link visibility in docs pages
- limit frequency-weight simulation to draws since 2025-01-25
- regenerate frequency simulation results for the new range
- handle empty frequency dataset and clean result formatting
- refine frequency predictor to honor new start date

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*

------
https://chatgpt.com/codex/tasks/task_e_685de110446c83249953282c9bfcad9f