### PR TITLE
Sort Frequency Simulation results by date DESC

### DIFF
--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -90,50 +90,50 @@
             </tr>
             </thead>
             <tbody>
-            <tr><td>2025-01-25</td><td>07-08-17-18-22-25</td><td>match 0 number, win number: The Classic Draw 01-14-19-27-32-40 Bonus (B): (37)</td><td>07-08-17-18-22-25</td><td>FREQ</td></tr>
-<tr><td>2025-01-29</td><td>01-14-19-27-32-37</td><td>match 0 number, win number: The Classic Draw 03-07-15-20-31-39 Bonus (B): (02)</td><td>01-14-19-27-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-02-01</td><td>01-02-03-07-14-15</td><td>match 1 number, win number: The Classic Draw 02-28-29-30-36-49 Bonus (B): (35)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
-<tr><td>2025-02-05</td><td>01-02-03-07-14-15</td><td>match 0 number, win number: The Classic Draw 04-13-20-32-37-46 Bonus (B): (33)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
-<tr><td>2025-02-08</td><td>01-02-03-20-32-37</td><td>match 1 number, win number: The Classic Draw 07-17-22-26-27-32 Bonus (B): (46)</td><td>01-02-03-20-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-02-12</td><td>02-07-20-27-32-37</td><td>match 0 number, win number: The Classic Draw 19-24-39-40-42-45 Bonus (B): (41)</td><td>02-07-20-27-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-02-15</td><td>02-07-19-20-27-32</td><td>match 0 number, win number: The Classic Draw 08-10-31-37-43-49 Bonus (B): (34)</td><td>02-07-19-20-27-32</td><td>FREQ</td></tr>
-<tr><td>2025-02-19</td><td>02-07-19-20-32-37</td><td>match 1 number, win number: The Classic Draw 09-10-11-24-31-37 Bonus (B): (44)</td><td>02-07-19-20-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-02-22</td><td>02-07-10-31-32-37</td><td>match 1 number, win number: The Classic Draw 07-13-29-39-47-48 Bonus (B): (26)</td><td>02-07-10-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-02-26</td><td>02-07-31-32-37-39</td><td>match 2 number, win number: The Classic Draw 07-19-20-26-31-35 Bonus (B): (40)</td><td>02-07-31-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-03-01</td><td>07-19-20-26-31-37</td><td>match 1 number, win number: The Classic Draw 15-19-25-33-40-42 Bonus (B): (13)</td><td>07-19-20-26-31-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-05</td><td>07-13-19-31-37-40</td><td>match 1 number, win number: The Classic Draw 09-11-26-36-37-42 Bonus (B): (24)</td><td>07-13-19-31-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-03-08</td><td>07-19-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-03-13-27-36-48 Bonus (B): (15)</td><td>07-19-26-31-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-03-12</td><td>07-13-19-26-31-37</td><td>match 1 number, win number: The Classic Draw 13-15-16-22-23-46 Bonus (B): (02)</td><td>07-13-19-26-31-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-15</td><td>02-07-13-15-19-37</td><td>match 2 number, win number: The Classic Draw 19-31-32-37-38-39 Bonus (B): (34)</td><td>02-07-13-15-19-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-19</td><td>02-07-13-19-31-37</td><td>match 1 number, win number: The Classic Draw 06-07-28-32-44-48 Bonus (B): (18)</td><td>02-07-13-19-31-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-22</td><td>07-13-19-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-03-13-16-26-32 Bonus (B): (21)</td><td>07-13-19-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-26</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 09-13-25-30-45-49 Bonus (B): (08)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-03-29</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 14-23-24-27-34-42 Bonus (B): (43)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-04-02</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 18-26-35-40-43-47 Bonus (B): (24)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-04-05</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 02-14-23-29-39-42 Bonus (B): (15)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-04-09</td><td>02-07-13-26-32-37</td><td>match 2 number, win number: The Classic Draw 11-18-26-35-37-39 Bonus (B): (16)</td><td>02-07-13-26-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-04-12</td><td>02-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 17-20-23-36-40-42 Bonus (B): (34)</td><td>02-13-26-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-04-16</td><td>13-26-32-37-39-40</td><td>match 3 number, win number: The Classic Draw 03-11-13-15-17-39 Bonus (B): (32)</td><td>13-26-32-37-39-40</td><td>FREQ</td></tr>
-<tr><td>2025-04-19</td><td>13-15-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 01-07-31-35-46-49 Bonus (B): (29)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-04-23</td><td>07-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 09-15-22-24-40-49 Bonus (B): (25)</td><td>07-13-26-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-04-26</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 18-22-28-32-38-44 Bonus (B): (20)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-04-30</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 01-09-12-15-34-35 Bonus (B): (31)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-05-03</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 12-22-25-30-36-41 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-05-07</td><td>13-15-26-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-04-08-13-16-26 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-05-10</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 05-12-17-19-40-47 Bonus (B): (29)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-05-14</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 01-08-17-18-41-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
-<tr><td>2025-05-17</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 07-09-20-34-38-46 Bonus (B): (14)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
-<tr><td>2025-05-21</td><td>07-13-15-26-32-40</td><td>match 1 number, win number: The Classic Draw 01-02-37-38-43-46 Bonus (B): (40)</td><td>07-13-15-26-32-40</td><td>FREQ</td></tr>
-<tr><td>2025-05-24</td><td>13-15-26-32-37-40</td><td>match 0 number, win number: The Classic Draw 04-08-18-27-28-31 Bonus (B): (48)</td><td>13-15-26-32-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-05-28</td><td>13-15-26-31-32-40</td><td>match 2 number, win number: The Classic Draw 06-13-28-31-34-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
-<tr><td>2025-05-31</td><td>13-15-26-31-32-40</td><td>match 1 number, win number: The Classic Draw 02-04-11-26-34-37 Bonus (B): (24)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
-<tr><td>2025-06-04</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 08-20-30-39-41-48 Bonus (B): (18)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-06-07</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-10-12-21-36-41 Bonus (B): (33)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-06-11</td><td>02-13-26-31-37-40</td><td>match 1 number, win number: The Classic Draw 04-09-23-28-32-39 Bonus (B): (26)</td><td>02-13-26-31-37-40</td><td>FREQ</td></tr>
-<tr><td>2025-06-14</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 05-08-20-28-35-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
-<tr><td>2025-06-18</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 08-14-20-25-30-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
+            <tr><td>2025-06-25</td><td>13-15-20-26-31-40</td><td>match 3 number, win number: The Classic Draw 04-08-15-20-40-49 Bonus (B): (37)</td><td>13-15-20-26-31-40</td><td>FREQ</td></tr>
 <tr><td>2025-06-21</td><td>13-20-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 14-15-17-38-40-49 Bonus (B): (23)</td><td>13-20-26-31-32-37</td><td>FREQ</td></tr>
-<tr><td>2025-06-25</td><td>13-15-20-26-31-40</td><td>match 3 number, win number: The Classic Draw 04-08-15-20-40-49 Bonus (B): (37)</td><td>13-15-20-26-31-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-18</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 08-14-20-25-30-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-06-14</td><td>13-26-31-32-37-39</td><td>match 0 number, win number: The Classic Draw 05-08-20-28-35-38 Bonus (B): (46)</td><td>13-26-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-06-11</td><td>02-13-26-31-37-40</td><td>match 1 number, win number: The Classic Draw 04-09-23-28-32-39 Bonus (B): (26)</td><td>02-13-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-07</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-10-12-21-36-41 Bonus (B): (33)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-06-04</td><td>13-15-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 08-20-30-39-41-48 Bonus (B): (18)</td><td>13-15-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-31</td><td>13-15-26-31-32-40</td><td>match 1 number, win number: The Classic Draw 02-04-11-26-34-37 Bonus (B): (24)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-28</td><td>13-15-26-31-32-40</td><td>match 2 number, win number: The Classic Draw 06-13-28-31-34-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-24</td><td>13-15-26-32-37-40</td><td>match 0 number, win number: The Classic Draw 04-08-18-27-28-31 Bonus (B): (48)</td><td>13-15-26-32-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-21</td><td>07-13-15-26-32-40</td><td>match 1 number, win number: The Classic Draw 01-02-37-38-43-46 Bonus (B): (40)</td><td>07-13-15-26-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-17</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 07-09-20-34-38-46 Bonus (B): (14)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-14</td><td>13-15-26-31-32-40</td><td>match 0 number, win number: The Classic Draw 01-08-17-18-41-48 Bonus (B): (42)</td><td>13-15-26-31-32-40</td><td>FREQ</td></tr>
+<tr><td>2025-05-10</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 05-12-17-19-40-47 Bonus (B): (29)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-05-07</td><td>13-15-26-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-04-08-13-16-26 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-05-03</td><td>13-15-26-31-32-37</td><td>match 0 number, win number: The Classic Draw 12-22-25-30-36-41 Bonus (B): (14)</td><td>13-15-26-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-30</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 01-09-12-15-34-35 Bonus (B): (31)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-26</td><td>13-15-26-32-37-39</td><td>match 1 number, win number: The Classic Draw 18-22-28-32-38-44 Bonus (B): (20)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-23</td><td>07-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 09-15-22-24-40-49 Bonus (B): (25)</td><td>07-13-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-19</td><td>13-15-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 01-07-31-35-46-49 Bonus (B): (29)</td><td>13-15-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-16</td><td>13-26-32-37-39-40</td><td>match 3 number, win number: The Classic Draw 03-11-13-15-17-39 Bonus (B): (32)</td><td>13-26-32-37-39-40</td><td>FREQ</td></tr>
+<tr><td>2025-04-12</td><td>02-13-26-32-37-39</td><td>match 0 number, win number: The Classic Draw 17-20-23-36-40-42 Bonus (B): (34)</td><td>02-13-26-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-04-09</td><td>02-07-13-26-32-37</td><td>match 2 number, win number: The Classic Draw 11-18-26-35-37-39 Bonus (B): (16)</td><td>02-07-13-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-05</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 02-14-23-29-39-42 Bonus (B): (15)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-04-02</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 18-26-35-40-43-47 Bonus (B): (24)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-29</td><td>07-13-19-26-32-37</td><td>match 0 number, win number: The Classic Draw 14-23-24-27-34-42 Bonus (B): (43)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-26</td><td>07-13-19-26-32-37</td><td>match 1 number, win number: The Classic Draw 09-13-25-30-45-49 Bonus (B): (08)</td><td>07-13-19-26-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-22</td><td>07-13-19-31-32-37</td><td>match 2 number, win number: The Classic Draw 01-03-13-16-26-32 Bonus (B): (21)</td><td>07-13-19-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-19</td><td>02-07-13-19-31-37</td><td>match 1 number, win number: The Classic Draw 06-07-28-32-44-48 Bonus (B): (18)</td><td>02-07-13-19-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-15</td><td>02-07-13-15-19-37</td><td>match 2 number, win number: The Classic Draw 19-31-32-37-38-39 Bonus (B): (34)</td><td>02-07-13-15-19-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-12</td><td>07-13-19-26-31-37</td><td>match 1 number, win number: The Classic Draw 13-15-16-22-23-46 Bonus (B): (02)</td><td>07-13-19-26-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-03-08</td><td>07-19-26-31-37-40</td><td>match 0 number, win number: The Classic Draw 02-03-13-27-36-48 Bonus (B): (15)</td><td>07-19-26-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-03-05</td><td>07-13-19-31-37-40</td><td>match 1 number, win number: The Classic Draw 09-11-26-36-37-42 Bonus (B): (24)</td><td>07-13-19-31-37-40</td><td>FREQ</td></tr>
+<tr><td>2025-03-01</td><td>07-19-20-26-31-37</td><td>match 1 number, win number: The Classic Draw 15-19-25-33-40-42 Bonus (B): (13)</td><td>07-19-20-26-31-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-26</td><td>02-07-31-32-37-39</td><td>match 2 number, win number: The Classic Draw 07-19-20-26-31-35 Bonus (B): (40)</td><td>02-07-31-32-37-39</td><td>FREQ</td></tr>
+<tr><td>2025-02-22</td><td>02-07-10-31-32-37</td><td>match 1 number, win number: The Classic Draw 07-13-29-39-47-48 Bonus (B): (26)</td><td>02-07-10-31-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-19</td><td>02-07-19-20-32-37</td><td>match 1 number, win number: The Classic Draw 09-10-11-24-31-37 Bonus (B): (44)</td><td>02-07-19-20-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-15</td><td>02-07-19-20-27-32</td><td>match 0 number, win number: The Classic Draw 08-10-31-37-43-49 Bonus (B): (34)</td><td>02-07-19-20-27-32</td><td>FREQ</td></tr>
+<tr><td>2025-02-12</td><td>02-07-20-27-32-37</td><td>match 0 number, win number: The Classic Draw 19-24-39-40-42-45 Bonus (B): (41)</td><td>02-07-20-27-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-08</td><td>01-02-03-20-32-37</td><td>match 1 number, win number: The Classic Draw 07-17-22-26-27-32 Bonus (B): (46)</td><td>01-02-03-20-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-02-05</td><td>01-02-03-07-14-15</td><td>match 0 number, win number: The Classic Draw 04-13-20-32-37-46 Bonus (B): (33)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
+<tr><td>2025-02-01</td><td>01-02-03-07-14-15</td><td>match 1 number, win number: The Classic Draw 02-28-29-30-36-49 Bonus (B): (35)</td><td>01-02-03-07-14-15</td><td>FREQ</td></tr>
+<tr><td>2025-01-29</td><td>01-14-19-27-32-37</td><td>match 0 number, win number: The Classic Draw 03-07-15-20-31-39 Bonus (B): (02)</td><td>01-14-19-27-32-37</td><td>FREQ</td></tr>
+<tr><td>2025-01-25</td><td>07-08-17-18-22-25</td><td>match 0 number, win number: The Classic Draw 01-14-19-27-32-40 Bonus (B): (37)</td><td>07-08-17-18-22-25</td><td>FREQ</td></tr>
             </tbody>
         </table>
     </div>

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -77,7 +77,7 @@ def main():
     cur.execute(
         'SELECT year, month, day, data FROM history_lotto '
         'WHERE (year * 10000 + month * 100 + day) >= ? '
-        'ORDER BY year ASC, month ASC, day ASC',
+        'ORDER BY year DESC, month DESC, day DESC',
         (start_val,)
     )
     rows = cur.fetchall()


### PR DESCRIPTION
## Summary
- show the latest draw at the top of the frequency simulation page
- query history lotto records in descending order

## Testing
- `PYTHONPATH=. python3 utils/generate_freq_sim_html.py`

------
https://chatgpt.com/codex/tasks/task_e_685de9c1063883249ea76498ce42d433