### PR TITLE
Add hit rate calculation per matched count

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -65,11 +65,17 @@ def update_html_with_win_status_and_predict_number():
         )
 
         matched_distribution_tables.append(f"<h3>{source}</h3>")
+        resolved_tickets = sum(data["distribution"].values())
         rows = []
         for i in range(7):
-            rows.append(f"<tr><td>{i}</td><td>{data['distribution'][i]}</td></tr>")
+            hit_rate = 0
+            if resolved_tickets:
+                hit_rate = data["distribution"][i] / resolved_tickets
+            rows.append(
+                f"<tr><td>{i}</td><td>{data['distribution'][i]}</td><td>{hit_rate:.2%}</td></tr>"
+            )
         matched_distribution_tables.append(
-            "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody>"
+            "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
             + "".join(rows) + "</tbody></table>"
         )
 

--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>33</td></tr><tr><th>Average Hit Rate</th><td>12.50%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>21</td></tr><tr><td>1</td><td>15</td></tr><tr><td>2</td><td>6</td></tr><tr><td>3</td><td>2</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>21</td><td>47.73%</td></tr><tr><td>1</td><td>15</td><td>34.09%</td></tr><tr><td>2</td><td>6</td><td>13.64%</td></tr><tr><td>3</td><td>2</td><td>4.55%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>35</td></tr><tr><th>Average Hit Rate</th><td>13.26%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LLM</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody><tr><td>0</td><td>12</td></tr><tr><td>1</td><td>27</td></tr><tr><td>2</td><td>4</td></tr><tr><td>3</td><td>0</td></tr><tr><td>4</td><td>0</td></tr><tr><td>5</td><td>0</td></tr><tr><td>6</td><td>0</td></tr></tbody></table>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>27</td><td>62.79%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -116,11 +116,17 @@ def main():
     )
 
     distribution_rows = []
+    resolved_tickets = sum(distribution.values())
     for i in range(7):
-        distribution_rows.append(f"<tr><td>{i}</td><td>{distribution[i]}</td></tr>")
+        hit_rate = 0
+        if resolved_tickets:
+            hit_rate = distribution[i] / resolved_tickets
+        distribution_rows.append(
+            f"<tr><td>{i}</td><td>{distribution[i]}</td><td>{hit_rate:.2%}</td></tr>"
+        )
     distribution_html = ["<h3>FREQ</h3>"]
     distribution_html.append(
-        "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th></tr></thead><tbody>"
+        "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
         + ''.join(distribution_rows) + "</tbody></table>"
     )
 


### PR DESCRIPTION
## Summary
- compute hit rate for 0-6 matched numbers in `auto_lotto_main.py`
- update frequency simulation HTML generation accordingly
- regenerate `index.html` and `freq_simulation.html`

## Testing
- `python -m py_compile auto_lotto_main.py utils/generate_freq_sim_html.py`


------
https://chatgpt.com/codex/tasks/task_e_685deb2fb8588324bc5cf387871c7309