### PR TITLE
Fix bonus matching for frequency simulation

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -182,7 +182,8 @@ def check_win_status():
 
         bought_numbers = re.findall(r"\d+", each_data["bought_numbers"])
         win_text = json.loads(result[0]["data"])["0"]
-        win_numbers = re.findall(r"\d+", win_text)[:6]
+        # also include the bonus number when determining matches
+        win_numbers = re.findall(r"\d+", win_text)[:7]
         count = sum(1 for n in bought_numbers if n in win_numbers)
         MY_DB.update_win_status(
             each_data["last_lotto_date"],

--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -73,10 +73,10 @@
 <main>
     <h2>Summary</h2>
     <h3>FREQ</h3>
-<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">
@@ -97,19 +97,19 @@
 <tr><td>2025-06-11</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw 05-08-20-28-35-38 Bonus (B): (46)</td><td>18(45) 07(41) 17(37) 42(37) 25(36) 39(35) 35(34) 08(33) 26(33) 34(33)</td><td>FREQ</td></tr>
 <tr><td>2025-06-07</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw 04-09-23-28-32-39 Bonus (B): (26)</td><td>18(45) 07(41) 42(38) 17(37) 25(37) 39(35) 26(34) 35(34) 08(33) 31(33)</td><td>FREQ</td></tr>
 <tr><td>2025-06-04</td><td>07-17-18-25-26-42</td><td>match 0 number, win number: The Classic Draw 02-10-12-21-36-41 Bonus (B): (33)</td><td>18(44) 07(41) 42(38) 17(37) 25(37) 26(34) 31(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
-<tr><td>2025-05-31</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 08-20-30-39-41-48 Bonus (B): (18)</td><td>18(44) 07(41) 42(38) 17(37) 25(37) 31(35) 35(34) 39(34) 26(33) 32(33)</td><td>FREQ</td></tr>
+<tr><td>2025-05-31</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 08-20-30-39-41-48 Bonus (B): (18)</td><td>18(44) 07(41) 42(38) 17(37) 25(37) 31(35) 35(34) 39(34) 26(33) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-28</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 02-04-11-26-34-37 Bonus (B): (24)</td><td>18(44) 07(41) 25(38) 17(37) 42(37) 31(34) 35(34) 39(34) 26(33) 32(33)</td><td>FREQ</td></tr>
-<tr><td>2025-05-24</td><td>07-17-18-25-26-42</td><td>match 0 number, win number: The Classic Draw 06-13-28-31-34-48 Bonus (B): (42)</td><td>18(43) 07(41) 25(38) 17(37) 42(37) 26(34) 35(34) 39(34) 31(33) 32(33)</td><td>FREQ</td></tr>
+<tr><td>2025-05-24</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw 06-13-28-31-34-48 Bonus (B): (42)</td><td>18(43) 07(41) 25(38) 17(37) 42(37) 26(34) 35(34) 39(34) 31(33) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-21</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw 04-08-18-27-28-31 Bonus (B): (48)</td><td>18(43) 07(42) 25(38) 17(37) 42(37) 26(34) 31(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-17</td><td>07-17-18-25-26-42</td><td>match 0 number, win number: The Classic Draw 01-02-37-38-43-46 Bonus (B): (40)</td><td>18(43) 07(41) 25(38) 17(37) 42(37) 26(34) 31(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-14</td><td>07-17-18-25-26-42</td><td>match 1 number, win number: The Classic Draw 07-09-20-34-38-46 Bonus (B): (14)</td><td>07(42) 18(42) 25(39) 17(36) 42(36) 26(34) 31(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
-<tr><td>2025-05-10</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw 01-08-17-18-41-48 Bonus (B): (42)</td><td>07(42) 18(42) 25(39) 42(37) 17(35) 31(35) 26(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
+<tr><td>2025-05-10</td><td>07-17-18-25-31-42</td><td>match 3 number, win number: The Classic Draw 01-08-17-18-41-48 Bonus (B): (42)</td><td>07(42) 18(42) 25(39) 42(37) 17(35) 31(35) 26(34) 35(34) 39(34) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-07</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 05-12-17-19-40-47 Bonus (B): (29)</td><td>07(42) 18(42) 25(39) 42(37) 17(35) 31(35) 35(34) 39(34) 26(33) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-05-03</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 01-04-08-13-16-26 Bonus (B): (14)</td><td>07(42) 18(42) 25(38) 42(38) 17(35) 31(35) 35(34) 39(34) 23(33) 26(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-30</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 12-22-25-30-36-41 Bonus (B): (14)</td><td>07(43) 18(42) 25(38) 42(38) 17(35) 31(34) 39(34) 23(33) 26(33) 32(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-26</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw 01-09-12-15-34-35 Bonus (B): (31)</td><td>07(43) 18(41) 25(38) 42(38) 17(35) 39(35) 31(34) 23(33) 26(33) 29(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-23</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw 18-22-28-32-38-44 Bonus (B): (20)</td><td>07(43) 18(41) 25(38) 42(38) 39(36) 17(35) 29(34) 31(34) 23(33) 26(33)</td><td>FREQ</td></tr>
-<tr><td>2025-04-19</td><td>07-17-18-25-39-42</td><td>match 0 number, win number: The Classic Draw 09-15-22-24-40-49 Bonus (B): (25)</td><td>07(42) 18(41) 25(38) 42(38) 39(36) 17(35) 23(33) 26(33) 29(33) 31(33)</td><td>FREQ</td></tr>
+<tr><td>2025-04-19</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw 09-15-22-24-40-49 Bonus (B): (25)</td><td>07(42) 18(41) 25(38) 42(38) 39(36) 17(35) 23(33) 26(33) 29(33) 31(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-16</td><td>07-17-18-25-39-42</td><td>match 1 number, win number: The Classic Draw 01-07-31-35-46-49 Bonus (B): (29)</td><td>07(42) 18(41) 25(38) 42(38) 17(35) 39(35) 23(33) 26(33) 29(33) 31(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-12</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw 03-11-13-15-17-39 Bonus (B): (32)</td><td>07(42) 18(41) 25(38) 42(37) 39(35) 17(34) 26(33) 29(33) 31(33) 35(33)</td><td>FREQ</td></tr>
 <tr><td>2025-04-09</td><td>07-17-18-25-39-42</td><td>match 2 number, win number: The Classic Draw 17-20-23-36-40-42 Bonus (B): (34)</td><td>07(42) 18(40) 25(38) 42(37) 17(34) 39(34) 23(33) 29(33) 31(33) 43(33)</td><td>FREQ</td></tr>
@@ -119,7 +119,7 @@
 <tr><td>2025-03-26</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 14-23-24-27-34-42 Bonus (B): (43)</td><td>07(42) 18(39) 25(37) 17(36) 42(36) 31(35) 39(33) 48(33) 03(32) 23(32)</td><td>FREQ</td></tr>
 <tr><td>2025-03-22</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 09-13-25-30-45-49 Bonus (B): (08)</td><td>07(42) 18(39) 25(37) 17(36) 42(36) 31(35) 39(33) 48(33) 22(32) 23(32)</td><td>FREQ</td></tr>
 <tr><td>2025-03-19</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 01-03-13-16-26-32 Bonus (B): (21)</td><td>07(42) 18(38) 25(37) 17(36) 42(36) 31(35) 39(34) 48(33) 22(32) 23(32)</td><td>FREQ</td></tr>
-<tr><td>2025-03-15</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 06-07-28-32-44-48 Bonus (B): (18)</td><td>07(43) 18(38) 25(37) 17(36) 42(36) 31(34) 39(33) 48(33) 22(32) 23(32)</td><td>FREQ</td></tr>
+<tr><td>2025-03-15</td><td>07-17-18-25-31-42</td><td>match 2 number, win number: The Classic Draw 06-07-28-32-44-48 Bonus (B): (18)</td><td>07(43) 18(38) 25(37) 17(36) 42(36) 31(34) 39(33) 48(33) 22(32) 23(32)</td><td>FREQ</td></tr>
 <tr><td>2025-03-12</td><td>07-17-18-25-31-42</td><td>match 1 number, win number: The Classic Draw 19-31-32-37-38-39 Bonus (B): (34)</td><td>07(43) 18(38) 25(37) 17(36) 42(36) 31(34) 27(33) 39(33) 48(33) 29(32)</td><td>FREQ</td></tr>
 <tr><td>2025-03-08</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 13-15-16-22-23-46 Bonus (B): (02)</td><td>07(43) 18(38) 25(37) 17(36) 42(36) 31(34) 29(33) 39(33) 22(32) 27(32)</td><td>FREQ</td></tr>
 <tr><td>2025-03-05</td><td>07-17-18-25-31-42</td><td>match 0 number, win number: The Classic Draw 02-03-13-27-36-48 Bonus (B): (15)</td><td>07(43) 18(38) 25(38) 17(36) 42(35) 31(34) 29(33) 39(33) 22(32) 27(32)</td><td>FREQ</td></tr>

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -39,7 +39,8 @@ def parse_numbers(data_str):
             first = ' '.join(first[0]) if isinstance(first[0], list) else ' '.join(first)
         text = str(first)
     text = re.sub(r"\s+", " ", text.strip())
-    numbers = [int(n) for n in re.findall(r"\d+", text)[:6]]
+    # include the bonus ball as well so we have seven numbers in total
+    numbers = [int(n) for n in re.findall(r"\d+", text)[:7]]
     return numbers, text
 
 


### PR DESCRIPTION
## Summary
- count the bonus ball when parsing win numbers in the frequency simulation generator
- include the bonus ball in win checks for buying history
- regenerate the frequency simulation HTML output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*
- `PYTHONPATH=. python utils/generate_freq_sim_html.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0b1e1dd483249c8954483be5cf17