### PR TITLE
Add simplejson

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -23,6 +23,7 @@ python-dotenv==1.0.1
 PyVirtualDisplay==3.0
 requests==2.32.3
 selenium==4.28.1
+simplejson
 sniffio==1.3.1
 sortedcontainers==2.4.0
 soupsieve==2.6


### PR DESCRIPTION
## Summary
- include `simplejson` as a dependency in `lib/requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simplejson')*

------
https://chatgpt.com/codex/tasks/task_e_685e0d333ec48324b6a0bb739414740e