### PR TITLE
Update README with simulation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ The available predictors include:
 The purchased tickets and their results are displayed on GitHub Pages.
 [https://l1nwatch.github.io/auto_market/](https://l1nwatch.github.io/auto_market/)
 
+You can also view the frequency-weighted simulation results here:
+[https://l1nwatch.github.io/auto_market/freq_simulation.html](https://l1nwatch.github.io/auto_market/freq_simulation.html)
+
 
 ### Design Overview
 


### PR DESCRIPTION
## Summary
- mention frequency-weighted lotto simulation page in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'easytrader')*

------
https://chatgpt.com/codex/tasks/task_e_685e9511d9248324a457aba7daff32ca