### PR TITLE
Add multi-year frequency simulations

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -96,6 +96,14 @@ def update_html_with_win_status_and_predict_number():
         html = html.replace("{{ need_to_be_replaced }}", "\n".join(format_buying_history))
         html = html.replace("{{ summary_tables }}", "\n".join(summary_tables))
         html = html.replace("{{ matched_distribution_tables }}", "\n".join(matched_distribution_tables))
+        nav_links = (
+            '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
+            '<a href="freq_simulation_2_year.html">2Y Freq Sim</a> | '
+            '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
+            '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
+            '<a href="freq_simulation_5_year.html">5Y Freq Sim</a>'
+        )
+        html = html.replace("{{ nav_links }}", nav_links)
     with open("docs/index.html", "w") as f:
         f.write(html)
 

--- a/docs/index_template.html
+++ b/docs/index_template.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Historical Lotto Results</h1>
     <nav>
-        <a href="freq_simulation.html">Frequency Simulation</a>
+        {{ nav_links }}
     </nav>
 </header>
 <main>

--- a/readme.md
+++ b/readme.md
@@ -27,13 +27,17 @@ This project uses various strategies to generate lottery numbers, automatically 
 The available predictors include:
 1. **LLM** - a language model suggests numbers based on recent draws.
 2. **Random** - generates purely random combinations.
-3. **Frequency-weighted** - analyzes the last two years of draws and selects the most common numbers.
+3. **Frequency-weighted** - analyzes historical draws to select the most common numbers. Simulations are available for 1–5 years of history.
 
 The purchased tickets and their results are displayed on GitHub Pages.
 [https://l1nwatch.github.io/auto_market/](https://l1nwatch.github.io/auto_market/)
 
 You can also view the frequency-weighted simulation results here:
-[https://l1nwatch.github.io/auto_market/freq_simulation.html](https://l1nwatch.github.io/auto_market/freq_simulation.html)
+[1 Year](https://l1nwatch.github.io/auto_market/freq_simulation_1_year.html) |
+[2 Years](https://l1nwatch.github.io/auto_market/freq_simulation_2_year.html) |
+[3 Years](https://l1nwatch.github.io/auto_market/freq_simulation_3_year.html) |
+[4 Years](https://l1nwatch.github.io/auto_market/freq_simulation_4_year.html) |
+[5 Years](https://l1nwatch.github.io/auto_market/freq_simulation_5_year.html)
 
 
 ### Design Overview

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -26,13 +26,17 @@
 可用的预测器包括：
 1. **LLM** - 根据最近的开奖数据由语言模型给出号码建议。
 2. **随机** - 生成完全随机的组合。
-3. **按频率加权** - 分析最近两年的开奖，选择出现次数最多的号码。
+3. **按频率加权** - 根据历史开奖选择出现次数最多的号码，可模拟1-5年的历史数据。
 
 购买的彩票及其结果会展示在 GitHub Pages 上。
 [https://l1nwatch.github.io/auto_market/](https://l1nwatch.github.io/auto_market/)
 
 也可以在这里查看按频率加权的模拟结果：
-[https://l1nwatch.github.io/auto_market/freq_simulation.html](https://l1nwatch.github.io/auto_market/freq_simulation.html)
+[1年](https://l1nwatch.github.io/auto_market/freq_simulation_1_year.html) |
+[2年](https://l1nwatch.github.io/auto_market/freq_simulation_2_year.html) |
+[3年](https://l1nwatch.github.io/auto_market/freq_simulation_3_year.html) |
+[4年](https://l1nwatch.github.io/auto_market/freq_simulation_4_year.html) |
+[5年](https://l1nwatch.github.io/auto_market/freq_simulation_5_year.html)
 
 
 ### 设计概览


### PR DESCRIPTION
## Summary
- support selecting historical range for frequency-weighted predictor
- generate 1-5 year frequency simulation pages
- update HTML template and lotto updater to include links to new pages
- document links in README files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea83980248324a70319234a67d45b