### PR TITLE
Fix navigation links layout

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -103,7 +103,7 @@ def update_html_with_win_status_and_predict_number():
             '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
             '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
             '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
-            '<a href="freq_simulation_all_years.html">All Freq Sim</a> | '
+            '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
             '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
             '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
             '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '

--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (2Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_1_year.html
+++ b/docs/freq_simulation_1_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (1Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_2_year.html
+++ b/docs/freq_simulation_2_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (2Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_3_year.html
+++ b/docs/freq_simulation_3_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (3Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_4_year.html
+++ b/docs/freq_simulation_4_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (4Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_5_year.html
+++ b/docs/freq_simulation_5_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (5Y)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/freq_simulation_all_years.html
+++ b/docs/freq_simulation_all_years.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Frequency Weighted Simulation (ALL)</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Historical Lotto Results</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a> | <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation.html
+++ b/docs/least_freq_simulation.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (2Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_1_year.html
+++ b/docs/least_freq_simulation_1_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (1Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br>        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_2_year.html
+++ b/docs/least_freq_simulation_2_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (2Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_3_year.html
+++ b/docs/least_freq_simulation_3_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (3Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_4_year.html
+++ b/docs/least_freq_simulation_4_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (4Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_5_year.html
+++ b/docs/least_freq_simulation_5_year.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (5Y)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/docs/least_freq_simulation_all_years.html
+++ b/docs/least_freq_simulation_all_years.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Least Frequency Weighted Simulation (ALL)</h1>
     <nav>
-        <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
+        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br> <a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a>
     </nav>
 </header>
 <main>

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -157,7 +157,7 @@ def generate_html_for_year(db, rows, years):
         '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
         '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
         '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
-        '<a href="freq_simulation_all_years.html">All Freq Sim</a> | '
+        '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
         '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
         '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
         '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '

--- a/utils/generate_least_freq_sim_html.py
+++ b/utils/generate_least_freq_sim_html.py
@@ -130,6 +130,12 @@ def generate_html_for_year(db, rows, years):
         html = f.read()
     html = html.replace('Historical Lotto Results', f'Least Frequency Weighted Simulation ({years_label})')
     nav_links = (
+        '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
+        '<a href="freq_simulation_2_year.html">2Y Freq Sim</a> | '
+        '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
+        '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
+        '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
+        '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
         '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
         '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
         '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '


### PR DESCRIPTION
## Summary
- break navigation links into two lines on least frequency pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603916ced883248558668ec62f35ad