### PR TITLE
Add simulations summary page

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -16,6 +16,7 @@ from utils.custom_db import MyLottoDB
 from utils.purchase_lotto_tickets import do_buying
 from utils.generate_freq_sim_html import main as generate_freq_sim_html
 from utils.generate_least_freq_sim_html import main as generate_least_freq_sim_html
+from utils.generate_simulations_summary_html import main as generate_simulations_summary_html
 
 __author__ = '__L1n__w@tch'
 
@@ -97,20 +98,7 @@ def update_html_with_win_status_and_predict_number():
         html = html.replace("{{ need_to_be_replaced }}", "\n".join(format_buying_history))
         html = html.replace("{{ summary_tables }}", "\n".join(summary_tables))
         html = html.replace("{{ matched_distribution_tables }}", "\n".join(matched_distribution_tables))
-        nav_links = (
-            '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
-            '<a href="freq_simulation_2_year.html">2Y Freq Sim</a> | '
-            '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
-            '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
-            '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
-            '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
-            '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
-            '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
-            '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '
-            '<a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | '
-            '<a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | '
-            '<a href="least_freq_simulation_all_years.html">All Least Freq Sim</a>'
-        )
+        nav_links = '<a href="simulations_summary.html">Simulations Summary</a>'
         html = html.replace("{{ nav_links }}", nav_links)
     with open("docs/index.html", "w") as f:
         f.write(html)
@@ -118,6 +106,7 @@ def update_html_with_win_status_and_predict_number():
     # also build the frequency-weighted simulation pages
     generate_freq_sim_html()
     generate_least_freq_sim_html()
+    generate_simulations_summary_html()
 
 
 def auto_purchase_lotto(last_lotto_date, number, source="LLM"):

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
 <header>
     <h1>Historical Lotto Results</h1>
     <nav>
-        <a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br><a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a>
+        <a href="simulations_summary.html">Simulations Summary</a>
     </nav>
 </header>
 <main>

--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simulations Summary</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        header {
+            background-color: #333;
+            color: white;
+            text-align: center;
+            padding: 1em 0;
+        }
+        header nav a {
+            color: #fff;
+            text-decoration: underline;
+        }
+        main {
+            padding: 20px;
+            overflow-x: auto; /* Enable horizontal scrolling if needed */
+        }
+        table {
+            width: 100%;
+            max-width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+            background: white;
+            display: block;
+            overflow-x: auto;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: center;
+            word-break: break-word;
+        }
+        th {
+            background-color: #333;
+            color: white;
+        }
+        th:nth-child(4), td:nth-child(4) {
+            word-break: break-word;
+        }
+        @media (max-width: 768px) {
+            body {
+                font-size: 14px;
+            }
+            table {
+                font-size: 12px;
+                display: block;
+                overflow-x: auto;
+                white-space: nowrap;
+            }
+            th, td {
+                padding: 5px;
+            }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Simulations Summary</h1>
+    <nav><a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br><a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a></nav>
+</header>
+<main>
+    <section>
+        <h2>Frequency Weighted Simulation (2Y)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-2Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-2Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section>
+    <section>
+        <h2>Least Frequency Weighted Simulation (2Y)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-2Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-2Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section>
+</main>
+</body>
+</html>

--- a/tests/test_html_generation.py
+++ b/tests/test_html_generation.py
@@ -69,12 +69,13 @@ def html_files(tmp_path, monkeypatch):
         tmp_dir / "docs" / "freq_simulation_all_years.html",
         tmp_dir / "docs" / "least_freq_simulation.html",
         tmp_dir / "docs" / "least_freq_simulation_all_years.html",
+        tmp_dir / "docs" / "simulations_summary.html",
         tmp_dir / "data" / "lotto.db",
     )
 
 
 def test_index_html_generation(html_files):
-    index_path, _, _, _, _, db_path = html_files
+    index_path, _, _, _, _, _, db_path = html_files
     assert index_path.exists(), "index.html should be generated"
 
     conn = sqlite3.connect(db_path)
@@ -97,12 +98,12 @@ def test_index_html_generation(html_files):
     assert cells[1] == latest_row[1]
     assert cells[2].startswith(latest_row[2].split()[0])
     assert cells[4] == latest_row[3]
-    # ensure navigation contains a link to the all-year simulation page
-    assert soup.find("a", href="freq_simulation_all_years.html") is not None
+    # ensure navigation contains a link to the simulations summary page
+    assert soup.find("a", href="simulations_summary.html") is not None
 
 
 def test_freq_simulation_html_generation(html_files):
-    _, freq_path, _, _, _, db_path = html_files
+    _, freq_path, _, _, _, _, db_path = html_files
     assert freq_path.exists(), "freq_simulation.html should be generated"
 
     conn = sqlite3.connect(db_path)
@@ -123,7 +124,7 @@ def test_freq_simulation_html_generation(html_files):
 
 
 def test_freq_simulation_all_years_html_generation(html_files):
-    _, _, all_path, _, _, db_path = html_files
+    _, _, all_path, _, _, _, db_path = html_files
     assert all_path.exists(), "freq_simulation_all_years.html should be generated"
 
     conn = sqlite3.connect(db_path)
@@ -145,7 +146,7 @@ def test_freq_simulation_all_years_html_generation(html_files):
 
 
 def test_least_freq_simulation_html_generation(html_files):
-    _, _, _, least_path, _, db_path = html_files
+    _, _, _, least_path, _, _, db_path = html_files
     assert least_path.exists(), "least_freq_simulation.html should be generated"
 
     conn = sqlite3.connect(db_path)
@@ -166,7 +167,7 @@ def test_least_freq_simulation_html_generation(html_files):
 
 
 def test_least_freq_simulation_all_years_html_generation(html_files):
-    _, _, _, _, least_all_path, db_path = html_files
+    _, _, _, _, least_all_path, _, db_path = html_files
     assert least_all_path.exists(), "least_freq_simulation_all_years.html should be generated"
 
     conn = sqlite3.connect(db_path)
@@ -185,3 +186,12 @@ def test_least_freq_simulation_all_years_html_generation(html_files):
     assert len(rows) == expected_rows
     first_cells = [c.get_text(strip=True) for c in rows[0].find_all("td")]
     assert first_cells[-1] == "LFREQ"
+
+
+def test_simulations_summary_html_generation(html_files):
+    _, _, _, _, _, summary_path, _ = html_files
+    assert summary_path.exists(), "simulations_summary.html should be generated"
+
+    soup = BeautifulSoup(summary_path.read_text(), "html.parser")
+    assert soup.find("h2", string=lambda x: x and "Frequency Weighted" in x)
+    assert soup.find("h2", string=lambda x: x and "Least Frequency" in x)

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate a summary page for all simulation results."""
+
+import os
+import re
+import utils.common as common
+
+
+def _extract_section(html: str) -> str:
+    match = re.search(r"(<h2>Summary.*?)(?:<h2>Results|</main>)", html, re.S)
+    return match.group(1).strip() if match else ""
+
+
+def _extract_heading(html: str) -> str:
+    match = re.search(r"<h1>(.*?)</h1>", html)
+    return match.group(1) if match else ""
+
+
+def main() -> str:
+    docs_dir = os.path.join(common.root, "docs")
+    freq_path = os.path.join(docs_dir, "freq_simulation.html")
+    least_path = os.path.join(docs_dir, "least_freq_simulation.html")
+
+    with open(freq_path, "r") as f:
+        freq_html = f.read()
+    with open(least_path, "r") as f:
+        least_html = f.read()
+
+    style_match = re.search(r"<style>(.*?)</style>", freq_html, re.S)
+    style = style_match.group(1) if style_match else ""
+
+    freq_heading = _extract_heading(freq_html)
+    least_heading = _extract_heading(least_html)
+    freq_section = _extract_section(freq_html)
+    least_section = _extract_section(least_html)
+
+    nav_links = (
+        '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
+        '<a href="freq_simulation_2_year.html">2Y Freq Sim</a> | '
+        '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
+        '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
+        '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
+        '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
+        '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
+        '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
+        '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '
+        '<a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | '
+        '<a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | '
+        '<a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | '
+        '<a href="index.html">Back to Results</a>'
+    )
+
+    html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <title>Simulations Summary</title>
+    <style>{style}</style>
+</head>
+<body>
+<header>
+    <h1>Simulations Summary</h1>
+    <nav>{nav_links}</nav>
+</header>
+<main>
+    <section>
+        <h2>{freq_heading}</h2>
+        {freq_section}
+    </section>
+    <section>
+        <h2>{least_heading}</h2>
+        {least_section}
+    </section>
+</main>
+</body>
+</html>
+"""
+    out_path = os.path.join(docs_dir, "simulations_summary.html")
+    with open(out_path, "w") as f:
+        f.write(html)
+    return out_path
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- build `simulations_summary.html` from existing simulation pages
- update index generation to link to the summary page
- update tests for the new summary html
- regenerate HTML docs with new navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68603c93b4fc8324a2938da5097566c1