### PR TITLE
Update simulations summary

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -70,6 +70,14 @@
 </header>
 <main>
     <section>
+        <h2>Frequency Weighted Simulation (1Y)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-1Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-1Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
         <h2>Frequency Weighted Simulation (2Y)</h2>
         <h2>Summary</h2>
     <h3>FREQ-2Y</h3>
@@ -77,8 +85,48 @@
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-2Y</h3>
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Frequency Weighted Simulation (3Y)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-3Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>27</td></tr><tr><th>Average Hit Rate</th><td>10.23%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-3Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Frequency Weighted Simulation (4Y)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-4Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-4Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Frequency Weighted Simulation (5Y)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-5Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>43</td></tr><tr><th>Average Hit Rate</th><td>16.29%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-5Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Frequency Weighted Simulation (ALL)</h2>
+        <h2>Summary</h2>
+    <h3>FREQ-ALL</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>FREQ-ALL</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section>
     <section>
+        <h2>Least Frequency Weighted Simulation (1Y)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-1Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-1Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
         <h2>Least Frequency Weighted Simulation (2Y)</h2>
         <h2>Summary</h2>
     <h3>LFREQ-2Y</h3>
@@ -86,6 +134,38 @@
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-2Y</h3>
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Least Frequency Weighted Simulation (3Y)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-3Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>41</td></tr><tr><th>Average Hit Rate</th><td>15.53%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-3Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Least Frequency Weighted Simulation (4Y)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-4Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>34</td></tr><tr><th>Average Hit Rate</th><td>12.88%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-4Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Least Frequency Weighted Simulation (5Y)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-5Y</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-5Y</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    </section><section>
+        <h2>Least Frequency Weighted Simulation (ALL)</h2>
+        <h2>Summary</h2>
+    <h3>LFREQ-ALL</h3>
+<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
+    <h3>Matched Count Distribution</h3>
+    <h3>LFREQ-ALL</h3>
+<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section>
 </main>
 </body>

--- a/tests/test_html_generation.py
+++ b/tests/test_html_generation.py
@@ -193,5 +193,13 @@ def test_simulations_summary_html_generation(html_files):
     assert summary_path.exists(), "simulations_summary.html should be generated"
 
     soup = BeautifulSoup(summary_path.read_text(), "html.parser")
-    assert soup.find("h2", string=lambda x: x and "Frequency Weighted" in x)
-    assert soup.find("h2", string=lambda x: x and "Least Frequency" in x)
+    freq_headings = soup.find_all(
+        "h2",
+        string=lambda x: x and "Frequency Weighted" in x and "Least" not in x,
+    )
+    least_headings = soup.find_all(
+        "h2",
+        string=lambda x: x and "Least Frequency Weighted" in x,
+    )
+    assert len(freq_headings) == 6
+    assert len(least_headings) == 6

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -19,21 +19,27 @@ def _extract_heading(html: str) -> str:
 
 def main() -> str:
     docs_dir = os.path.join(common.root, "docs")
-    freq_path = os.path.join(docs_dir, "freq_simulation.html")
-    least_path = os.path.join(docs_dir, "least_freq_simulation.html")
 
-    with open(freq_path, "r") as f:
-        freq_html = f.read()
-    with open(least_path, "r") as f:
-        least_html = f.read()
+    def build_sections(prefix: str) -> list[str]:
+        sections = []
+        for years in [1, 2, 3, 4, 5, "all"]:
+            suffix = f"{years}_year" if years != "all" else "all_years"
+            path = os.path.join(docs_dir, f"{prefix}_{suffix}.html")
+            with open(path, "r") as f:
+                html = f.read()
+            heading = _extract_heading(html)
+            section = _extract_section(html)
+            sections.append(f"<section>\n        <h2>{heading}</h2>\n        {section}\n    </section>")
+        return sections
 
-    style_match = re.search(r"<style>(.*?)</style>", freq_html, re.S)
+    # Use the 2 year frequency simulation to obtain common styles
+    with open(os.path.join(docs_dir, "freq_simulation.html"), "r") as f:
+        style_html = f.read()
+    style_match = re.search(r"<style>(.*?)</style>", style_html, re.S)
     style = style_match.group(1) if style_match else ""
 
-    freq_heading = _extract_heading(freq_html)
-    least_heading = _extract_heading(least_html)
-    freq_section = _extract_section(freq_html)
-    least_section = _extract_section(least_html)
+    freq_sections = build_sections("freq_simulation")
+    least_sections = build_sections("least_freq_simulation")
 
     nav_links = (
         '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
@@ -65,14 +71,8 @@ def main() -> str:
     <nav>{nav_links}</nav>
 </header>
 <main>
-    <section>
-        <h2>{freq_heading}</h2>
-        {freq_section}
-    </section>
-    <section>
-        <h2>{least_heading}</h2>
-        {least_section}
-    </section>
+    {"".join(freq_sections)}
+    {"".join(least_sections)}
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend summary generator to include all year simulations
- verify all 6 most and least frequency summaries are present
- regenerate simulations summary HTML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686041577ab08324bdc1d4ee3553ffae