### PR TITLE
Improve summary layout

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -61,7 +61,10 @@
                 padding: 5px;
             }
         }
-    </style>
+    
+.summary-sections{display:flex;flex-wrap:wrap;gap:20px;}
+.summary-sections section{flex:1 1 300px;}
+</style>
 </head>
 <body>
 <header>
@@ -69,7 +72,7 @@
     <nav><a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br><a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a></nav>
 </header>
 <main>
-    <section>
+    <div class="summary-sections"><section>
         <h2>Frequency Weighted Simulation (1Y)</h2>
         <h2>Summary</h2>
     <h3>FREQ-1Y</h3>
@@ -117,8 +120,8 @@
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-ALL</h3>
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
-    </section>
-    <section>
+    </section></div>
+    <div class="summary-sections"><section>
         <h2>Least Frequency Weighted Simulation (1Y)</h2>
         <h2>Summary</h2>
     <h3>LFREQ-1Y</h3>
@@ -166,7 +169,7 @@
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-ALL</h3>
 <table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
-    </section>
+    </section></div>
 </main>
 </body>
 </html>

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -37,6 +37,11 @@ def main() -> str:
         style_html = f.read()
     style_match = re.search(r"<style>(.*?)</style>", style_html, re.S)
     style = style_match.group(1) if style_match else ""
+    style += (
+        "\n.summary-sections{display:flex;flex-wrap:wrap;gap:20px;}"
+        "\n.summary-sections section{flex:1 1 300px;}"
+        "\n"
+    )
 
     freq_sections = build_sections("freq_simulation")
     least_sections = build_sections("least_freq_simulation")
@@ -57,6 +62,9 @@ def main() -> str:
         '<a href="index.html">Back to Results</a>'
     )
 
+    freq_html = '<div class="summary-sections">' + ''.join(freq_sections) + '</div>'
+    least_html = '<div class="summary-sections">' + ''.join(least_sections) + '</div>'
+
     html = f"""<!DOCTYPE html>
 <html lang=\"en\">
 <head>
@@ -71,8 +79,8 @@ def main() -> str:
     <nav>{nav_links}</nav>
 </header>
 <main>
-    {"".join(freq_sections)}
-    {"".join(least_sections)}
+    {freq_html}
+    {least_html}
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refine CSS for horizontal summaries
- regenerate simulations summary HTML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68604546f5248324b8c0e8c2226c7c19