### PR TITLE
Adjust summary layout

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -62,8 +62,8 @@
             }
         }
     
-.summary-sections{display:flex;flex-wrap:wrap;gap:20px;}
-.summary-sections section{flex:1 1 300px;}
+.summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}
+.summary-sections section{flex:0 0 300px;}
 </style>
 </head>
 <body>

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -38,8 +38,8 @@ def main() -> str:
     style_match = re.search(r"<style>(.*?)</style>", style_html, re.S)
     style = style_match.group(1) if style_match else ""
     style += (
-        "\n.summary-sections{display:flex;flex-wrap:wrap;gap:20px;}"
-        "\n.summary-sections section{flex:1 1 300px;}"
+        "\n.summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}"
+        "\n.summary-sections section{flex:0 0 300px;}"
         "\n"
     )
 


### PR DESCRIPTION
## Summary
- tweak CSS so *All* simulations appear on the same row as 1-5Y ones
- regenerate Simulations Summary HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860483f8fbc8324a9b6a2cff4533a78