### PR TITLE
Improve summary layout and distribution table

### DIFF
--- a/docs/freq_simulation.html
+++ b/docs/freq_simulation.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_1_year.html
+++ b/docs/freq_simulation_1_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-1Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_2_year.html
+++ b/docs/freq_simulation_2_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_3_year.html
+++ b/docs/freq_simulation_3_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>27</td></tr><tr><th>Average Hit Rate</th><td>10.23%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-3Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_4_year.html
+++ b/docs/freq_simulation_4_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-4Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_5_year.html
+++ b/docs/freq_simulation_5_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>43</td></tr><tr><th>Average Hit Rate</th><td>16.29%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-5Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/freq_simulation_all_years.html
+++ b/docs/freq_simulation_all_years.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-ALL</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation.html
+++ b/docs/least_freq_simulation.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_1_year.html
+++ b/docs/least_freq_simulation_1_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-1Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_2_year.html
+++ b/docs/least_freq_simulation_2_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_3_year.html
+++ b/docs/least_freq_simulation_3_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>41</td></tr><tr><th>Average Hit Rate</th><td>15.53%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-3Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_4_year.html
+++ b/docs/least_freq_simulation_4_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>34</td></tr><tr><th>Average Hit Rate</th><td>12.88%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-4Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_5_year.html
+++ b/docs/least_freq_simulation_5_year.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-5Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/least_freq_simulation_all_years.html
+++ b/docs/least_freq_simulation_all_years.html
@@ -76,7 +76,7 @@
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-ALL</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">

--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -64,6 +64,10 @@
     
 .summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}
 .summary-sections section{flex:0 0 300px;}
+.distribution-table{table-layout:fixed;width:100%;}
+.distribution-table th:nth-child(1), .distribution-table td:nth-child(1){width:33%;}
+.distribution-table th:nth-child(2), .distribution-table td:nth-child(2){width:33%;}
+.distribution-table th:nth-child(3), .distribution-table td:nth-child(3){width:34%;}
 </style>
 </head>
 <body>
@@ -74,101 +78,89 @@
 <main>
     <div class="summary-sections"><section>
         <h2>Frequency Weighted Simulation (1Y)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-1Y</h3>
+        <h3>FREQ-1Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-1Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (2Y)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-2Y</h3>
+        <h3>FREQ-2Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (3Y)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-3Y</h3>
+        <h3>FREQ-3Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>27</td></tr><tr><th>Average Hit Rate</th><td>10.23%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-3Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (4Y)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-4Y</h3>
+        <h3>FREQ-4Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-4Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (5Y)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-5Y</h3>
+        <h3>FREQ-5Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>43</td></tr><tr><th>Average Hit Rate</th><td>16.29%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-5Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (ALL)</h2>
-        <h2>Summary</h2>
-    <h3>FREQ-ALL</h3>
+        <h3>FREQ-ALL</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>FREQ-ALL</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section></div>
     <div class="summary-sections"><section>
         <h2>Least Frequency Weighted Simulation (1Y)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-1Y</h3>
+        <h3>LFREQ-1Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-1Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (2Y)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-2Y</h3>
+        <h3>LFREQ-2Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-2Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (3Y)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-3Y</h3>
+        <h3>LFREQ-3Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>41</td></tr><tr><th>Average Hit Rate</th><td>15.53%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-3Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (4Y)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-4Y</h3>
+        <h3>LFREQ-4Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>34</td></tr><tr><th>Average Hit Rate</th><td>12.88%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-4Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (5Y)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-5Y</h3>
+        <h3>LFREQ-5Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-5Y</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (ALL)</h2>
-        <h2>Summary</h2>
-    <h3>LFREQ-ALL</h3>
+        <h3>LFREQ-ALL</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
     <h3>LFREQ-ALL</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+<table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section></div>
 </main>
 </body>

--- a/utils/generate_freq_sim_html.py
+++ b/utils/generate_freq_sim_html.py
@@ -143,7 +143,7 @@ def generate_html_for_year(db, rows, years):
         )
     distribution_html = [f"<h3>FREQ-{years_label}</h3>"]
     distribution_html.append(
-        "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
+        "<table class=\"distribution-table\"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
         + ''.join(distribution_rows) + "</tbody></table>"
     )
 

--- a/utils/generate_least_freq_sim_html.py
+++ b/utils/generate_least_freq_sim_html.py
@@ -121,7 +121,7 @@ def generate_html_for_year(db, rows, years):
         )
     distribution_html = [f"<h3>LFREQ-{years_label}</h3>"]
     distribution_html.append(
-        "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
+        "<table class=\"distribution-table\"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
         + ''.join(distribution_rows) + "</tbody></table>"
     )
 

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -8,7 +8,7 @@ import utils.common as common
 
 
 def _extract_section(html: str) -> str:
-    match = re.search(r"(<h2>Summary.*?)(?:<h2>Results|</main>)", html, re.S)
+    match = re.search(r"<h2>Summary</h2>(.*?)(?:<h2>Results|</main>)", html, re.S)
     return match.group(1).strip() if match else ""
 
 
@@ -40,6 +40,10 @@ def main() -> str:
     style += (
         "\n.summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}"
         "\n.summary-sections section{flex:0 0 300px;}"
+        "\n.distribution-table{table-layout:fixed;width:100%;}"
+        "\n.distribution-table th:nth-child(1), .distribution-table td:nth-child(1){width:33%;}"
+        "\n.distribution-table th:nth-child(2), .distribution-table td:nth-child(2){width:33%;}"
+        "\n.distribution-table th:nth-child(3), .distribution-table td:nth-child(3){width:34%;}"
         "\n"
     )
 


### PR DESCRIPTION
## Summary
- tweak summary section extraction
- make distribution table columns fixed-width
- mark matched distribution tables with a new class
- regenerate HTML docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604a8ae9f88324abe6f1081bfe1095