### PR TITLE
Fix summary table spacing

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -64,6 +64,7 @@
     
 .summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}
 .summary-sections section{flex:0 0 300px;}
+.summary-sections table{display:table;width:100%;}
 .distribution-table{table-layout:fixed;width:100%;}
 .distribution-table th:nth-child(1), .distribution-table td:nth-child(1){width:33%;}
 .distribution-table th:nth-child(2), .distribution-table td:nth-child(2){width:33%;}

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -40,6 +40,7 @@ def main() -> str:
     style += (
         "\n.summary-sections{display:flex;flex-wrap:nowrap;gap:20px;overflow-x:auto;}"
         "\n.summary-sections section{flex:0 0 300px;}"
+        "\n.summary-sections table{display:table;width:100%;}"
         "\n.distribution-table{table-layout:fixed;width:100%;}"
         "\n.distribution-table th:nth-child(1), .distribution-table td:nth-child(1){width:33%;}"
         "\n.distribution-table th:nth-child(2), .distribution-table td:nth-child(2){width:33%;}"


### PR DESCRIPTION
## Summary
- ensure summary section tables render as normal table elements
- regenerate Simulations Summary page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604db198ac8324aecd75cab8a52f24