### PR TITLE
Remove redundant labels from summary

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -79,88 +79,64 @@
 <main>
     <div class="summary-sections"><section>
         <h2>Frequency Weighted Simulation (1Y)</h2>
-        <h3>FREQ-1Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-1Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (2Y)</h2>
-        <h3>FREQ-2Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-2Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (3Y)</h2>
-        <h3>FREQ-3Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>27</td></tr><tr><th>Average Hit Rate</th><td>10.23%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-3Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (4Y)</h2>
-        <h3>FREQ-4Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-4Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (5Y)</h2>
-        <h3>FREQ-5Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>43</td></tr><tr><th>Average Hit Rate</th><td>16.29%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-5Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Frequency Weighted Simulation (ALL)</h2>
-        <h3>FREQ-ALL</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>FREQ-ALL</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section></div>
     <div class="summary-sections"><section>
         <h2>Least Frequency Weighted Simulation (1Y)</h2>
-        <h3>LFREQ-1Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-1Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (2Y)</h2>
-        <h3>LFREQ-2Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-2Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (3Y)</h2>
-        <h3>LFREQ-3Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>41</td></tr><tr><th>Average Hit Rate</th><td>15.53%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-3Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (4Y)</h2>
-        <h3>LFREQ-4Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>34</td></tr><tr><th>Average Hit Rate</th><td>12.88%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-4Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (5Y)</h2>
-        <h3>LFREQ-5Y</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-5Y</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
         <h2>Least Frequency Weighted Simulation (ALL)</h2>
-        <h3>LFREQ-ALL</h3>
 <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
     <h3>Matched Count Distribution</h3>
-    <h3>LFREQ-ALL</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section></div>
 </main>

--- a/tests/test_html_generation.py
+++ b/tests/test_html_generation.py
@@ -203,3 +203,9 @@ def test_simulations_summary_html_generation(html_files):
     )
     assert len(freq_headings) == 6
     assert len(least_headings) == 6
+
+    labels = soup.find_all(
+        "h3",
+        string=lambda x: x and ("FREQ-" in x or "LFREQ-" in x),
+    )
+    assert not labels

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -9,7 +9,12 @@ import utils.common as common
 
 def _extract_section(html: str) -> str:
     match = re.search(r"<h2>Summary</h2>(.*?)(?:<h2>Results|</main>)", html, re.S)
-    return match.group(1).strip() if match else ""
+    if not match:
+        return ""
+    section = match.group(1).strip()
+    # remove redundant FREQ/LFREQ headings in summary blocks
+    section = re.sub(r"<h3>\s*(?:L?FREQ-[^<]*)</h3>", "", section)
+    return section
 
 
 def _extract_heading(html: str) -> str:


### PR DESCRIPTION
## Summary
- clean up the generated `simulations_summary.html` by stripping out FREQ/LFREQ sub-headings
- test that these labels are not present in the summary page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604f5fda0c8324ab668a3c5927a644