### PR TITLE
Update simulation summary headings

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -78,63 +78,63 @@
 </header>
 <main>
     <div class="summary-sections"><section>
-        <h2>Frequency Weighted Simulation (1Y)</h2>
+        <h2>(1Y)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>15</td><td>34.88%</td></tr><tr><td>2</td><td>11</td><td>25.58%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Frequency Weighted Simulation (2Y)</h2>
+        <h2>(2Y)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Frequency Weighted Simulation (3Y)</h2>
+        <h2>(3Y)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>27</td></tr><tr><th>Average Hit Rate</th><td>10.23%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>19</td><td>44.19%</td></tr><tr><td>2</td><td>4</td><td>9.30%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Frequency Weighted Simulation (4Y)</h2>
+        <h2>(4Y)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>16</td><td>37.21%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Frequency Weighted Simulation (5Y)</h2>
+        <h2>(5Y)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>43</td></tr><tr><th>Average Hit Rate</th><td>16.29%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>21</td><td>48.84%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Frequency Weighted Simulation (ALL)</h2>
+        <h2>(ALL)Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>20</td><td>46.51%</td></tr><tr><td>1</td><td>12</td><td>27.91%</td></tr><tr><td>2</td><td>9</td><td>20.93%</td></tr><tr><td>3</td><td>2</td><td>4.65%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section></div>
     <div class="summary-sections"><section>
-        <h2>Least Frequency Weighted Simulation (1Y)</h2>
+        <h2>(1Y)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>32</td></tr><tr><th>Average Hit Rate</th><td>12.12%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>18</td><td>41.86%</td></tr><tr><td>1</td><td>18</td><td>41.86%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Least Frequency Weighted Simulation (2Y)</h2>
+        <h2>(2Y)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>37</td></tr><tr><th>Average Hit Rate</th><td>14.02%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>7</td><td>16.28%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Least Frequency Weighted Simulation (3Y)</h2>
+        <h2>(3Y)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>41</td></tr><tr><th>Average Hit Rate</th><td>15.53%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.91%</td></tr><tr><td>1</td><td>22</td><td>51.16%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Least Frequency Weighted Simulation (4Y)</h2>
+        <h2>(4Y)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>34</td></tr><tr><th>Average Hit Rate</th><td>12.88%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>14</td><td>32.56%</td></tr><tr><td>1</td><td>24</td><td>55.81%</td></tr><tr><td>2</td><td>5</td><td>11.63%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Least Frequency Weighted Simulation (5Y)</h2>
+        <h2>(5Y)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>20</td><td>46.51%</td></tr><tr><td>2</td><td>8</td><td>18.60%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
     </section><section>
-        <h2>Least Frequency Weighted Simulation (ALL)</h2>
+        <h2>(ALL)Least Frequency Weighted Simulation</h2>
         <table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>40</td></tr><tr><th>Average Hit Rate</th><td>15.15%</td></tr></table>
 <h3>Matched Count Distribution</h3>
 <table class="distribution-table"><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>15</td><td>34.88%</td></tr><tr><td>1</td><td>17</td><td>39.53%</td></tr><tr><td>2</td><td>10</td><td>23.26%</td></tr><tr><td>3</td><td>1</td><td>2.33%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -41,6 +41,9 @@ def main() -> str:
             with open(path, "r") as f:
                 html = f.read()
             heading = _extract_heading(html)
+            match = re.match(r"(.*) \(([^)]+)\)", heading)
+            if match:
+                heading = f"({match.group(2)}){match.group(1).strip()}"
             content = _strip_labels(summary)
             if dist:
                 content += "\n<h3>Matched Count Distribution</h3>\n" + _strip_labels(dist)


### PR DESCRIPTION
## Summary
- adjust heading order in simulations summary generator
- regenerate `simulations_summary.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686056d8721c8324b6130085cd9d833e