### PR TITLE
Update simulations summary navigation links

### DIFF
--- a/docs/simulations_summary.html
+++ b/docs/simulations_summary.html
@@ -74,7 +74,7 @@
 <body>
 <header>
     <h1>Simulations Summary</h1>
-    <nav><a href="freq_simulation_1_year.html">1Y Freq Sim</a> | <a href="freq_simulation_2_year.html">2Y Freq Sim</a> | <a href="freq_simulation_3_year.html">3Y Freq Sim</a> | <a href="freq_simulation_4_year.html">4Y Freq Sim</a> | <a href="freq_simulation_5_year.html">5Y Freq Sim</a> | <a href="freq_simulation_all_years.html">All Freq Sim</a><br><a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | <a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | <a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | <a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | <a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | <a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | <a href="index.html">Back to Results</a></nav>
+    <nav>Freq Sim: [<a href="freq_simulation_1_year.html">1Y</a>, <a href="freq_simulation_2_year.html">2Y</a>, <a href="freq_simulation_3_year.html">3Y</a>, <a href="freq_simulation_4_year.html">4Y</a>, <a href="freq_simulation_5_year.html">5Y</a>, <a href="freq_simulation_all_years.html">ALL</a>] | Least Freq Sim: [<a href="least_freq_simulation_1_year.html">1Y</a>, <a href="least_freq_simulation_2_year.html">2Y</a>, <a href="least_freq_simulation_3_year.html">3Y</a>, <a href="least_freq_simulation_4_year.html">4Y</a>, <a href="least_freq_simulation_5_year.html">5Y</a>, <a href="least_freq_simulation_all_years.html">ALL</a>] | <a href="index.html">Back to Results</a></nav>
 </header>
 <main>
     <div class="summary-sections"><section>

--- a/utils/generate_simulations_summary_html.py
+++ b/utils/generate_simulations_summary_html.py
@@ -72,18 +72,21 @@ def main() -> str:
     least_sections = build_sections(lfreq_module.generate_html_for_year)
 
     nav_links = (
-        '<a href="freq_simulation_1_year.html">1Y Freq Sim</a> | '
-        '<a href="freq_simulation_2_year.html">2Y Freq Sim</a> | '
-        '<a href="freq_simulation_3_year.html">3Y Freq Sim</a> | '
-        '<a href="freq_simulation_4_year.html">4Y Freq Sim</a> | '
-        '<a href="freq_simulation_5_year.html">5Y Freq Sim</a> | '
-        '<a href="freq_simulation_all_years.html">All Freq Sim</a><br>'
-        '<a href="least_freq_simulation_1_year.html">1Y Least Freq Sim</a> | '
-        '<a href="least_freq_simulation_2_year.html">2Y Least Freq Sim</a> | '
-        '<a href="least_freq_simulation_3_year.html">3Y Least Freq Sim</a> | '
-        '<a href="least_freq_simulation_4_year.html">4Y Least Freq Sim</a> | '
-        '<a href="least_freq_simulation_5_year.html">5Y Least Freq Sim</a> | '
-        '<a href="least_freq_simulation_all_years.html">All Least Freq Sim</a> | '
+        'Freq Sim: ['
+        '<a href="freq_simulation_1_year.html">1Y</a>, '
+        '<a href="freq_simulation_2_year.html">2Y</a>, '
+        '<a href="freq_simulation_3_year.html">3Y</a>, '
+        '<a href="freq_simulation_4_year.html">4Y</a>, '
+        '<a href="freq_simulation_5_year.html">5Y</a>, '
+        '<a href="freq_simulation_all_years.html">ALL</a>'
+        '] | Least Freq Sim: ['
+        '<a href="least_freq_simulation_1_year.html">1Y</a>, '
+        '<a href="least_freq_simulation_2_year.html">2Y</a>, '
+        '<a href="least_freq_simulation_3_year.html">3Y</a>, '
+        '<a href="least_freq_simulation_4_year.html">4Y</a>, '
+        '<a href="least_freq_simulation_5_year.html">5Y</a>, '
+        '<a href="least_freq_simulation_all_years.html">ALL</a>'
+        '] | '
         '<a href="index.html">Back to Results</a>'
     )
 


### PR DESCRIPTION
## Summary
- tweak navigation links in `generate_simulations_summary_html.py`
- regenerate `simulations_summary.html` with new link layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605997e6ec8324a1bfbe53085a46b3