### PR TITLE
Align summary tables

### DIFF
--- a/auto_lotto_main.py
+++ b/auto_lotto_main.py
@@ -52,21 +52,25 @@ def update_html_with_win_status_and_predict_number():
                 group_summary[source]["distribution"][count] += 1
 
     # build summary and distribution tables
-    summary_tables = []
-    matched_distribution_tables = []
+    summary_table_sections = []
+    distribution_table_sections = []
     for source, data in group_summary.items():
-        summary_tables.append(f"<h3>{source}</h3>")
+        # build summary table for a source
+        section_parts = [f"<h3>{source}</h3>"]
         avg_hit_rate = 0
         if data["total_tickets"] > 0:
             avg_hit_rate = data["total_win_numbers"] / (data["total_tickets"] * 6)
 
-        summary_tables.append(
+        section_parts.append(
             f"<table><tr><th>Total Tickets Bought</th><td>{data['total_tickets']}</td></tr>"
             f"<tr><th>Total Win Numbers</th><td>{data['total_win_numbers']}</td></tr>"
             f"<tr><th>Average Hit Rate</th><td>{avg_hit_rate:.2%}</td></tr></table>"
         )
+        summary_table_sections.append("<div>" + "".join(section_parts) + "</div>")
 
-        matched_distribution_tables.append(f"<h3>{source}</h3>")
+        # build matched distribution table for a source
+        dist_parts = [f"<h3>{source}</h3>"]
+        avg_hit_rate = 0
         resolved_tickets = sum(data["distribution"].values())
         rows = []
         for i in range(7):
@@ -76,10 +80,23 @@ def update_html_with_win_status_and_predict_number():
             rows.append(
                 f"<tr><td>{i}</td><td>{data['distribution'][i]}</td><td>{hit_rate:.2%}</td></tr>"
             )
-        matched_distribution_tables.append(
+        dist_parts.append(
             "<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody>"
-            + "".join(rows) + "</tbody></table>"
+            + "".join(rows)
+            + "</tbody></table>"
         )
+        distribution_table_sections.append("<div>" + "".join(dist_parts) + "</div>")
+
+    summary_tables = (
+        '<div style="display:flex;gap:20px;flex-wrap:wrap;">'
+        + "".join(summary_table_sections)
+        + "</div>"
+    )
+    matched_distribution_tables = (
+        '<div style="display:flex;gap:20px;flex-wrap:wrap;">'
+        + "".join(distribution_table_sections)
+        + "</div>"
+    )
 
     # format buying history
     format_buying_history = []
@@ -96,8 +113,8 @@ def update_html_with_win_status_and_predict_number():
     with open("docs/index_template.html", "r") as f:
         html = f.read()
         html = html.replace("{{ need_to_be_replaced }}", "\n".join(format_buying_history))
-        html = html.replace("{{ summary_tables }}", "\n".join(summary_tables))
-        html = html.replace("{{ matched_distribution_tables }}", "\n".join(matched_distribution_tables))
+        html = html.replace("{{ summary_tables }}", summary_tables)
+        html = html.replace("{{ matched_distribution_tables }}", matched_distribution_tables)
         nav_links = '<a href="simulations_summary.html">Simulations Summary</a>'
         html = html.replace("{{ nav_links }}", nav_links)
     with open("docs/index.html", "w") as f:

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,15 +72,9 @@
 </header>
 <main>
     <h2>Summary</h2>
-    <h3>RANDOM</h3>
-<table><tr><th>Total Tickets Bought</th><td>1</td></tr><tr><th>Total Win Numbers</th><td>0</td></tr><tr><th>Average Hit Rate</th><td>0.00%</td></tr></table>
-<h3>LLM</h3>
-<table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table>
+    <div style="display:flex;gap:20px;flex-wrap:wrap;"><div><h3>RANDOM</h3><table><tr><th>Total Tickets Bought</th><td>1</td></tr><tr><th>Total Win Numbers</th><td>0</td></tr><tr><th>Average Hit Rate</th><td>0.00%</td></tr></table></div><div><h3>LLM</h3><table><tr><th>Total Tickets Bought</th><td>44</td></tr><tr><th>Total Win Numbers</th><td>36</td></tr><tr><th>Average Hit Rate</th><td>13.64%</td></tr></table></div></div>
     <h3>Matched Count Distribution</h3>
-    <h3>RANDOM</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>0</td><td>0.00%</td></tr><tr><td>1</td><td>0</td><td>0.00%</td></tr><tr><td>2</td><td>0</td><td>0.00%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
-<h3>LLM</h3>
-<table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.27%</td></tr><tr><td>1</td><td>28</td><td>63.64%</td></tr><tr><td>2</td><td>4</td><td>9.09%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table>
+    <div style="display:flex;gap:20px;flex-wrap:wrap;"><div><h3>RANDOM</h3><table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>0</td><td>0.00%</td></tr><tr><td>1</td><td>0</td><td>0.00%</td></tr><tr><td>2</td><td>0</td><td>0.00%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table></div><div><h3>LLM</h3><table><thead><tr><th>Matched Numbers</th><th>Ticket Count</th><th>Hit Rate</th></tr></thead><tbody><tr><td>0</td><td>12</td><td>27.27%</td></tr><tr><td>1</td><td>28</td><td>63.64%</td></tr><tr><td>2</td><td>4</td><td>9.09%</td></tr><tr><td>3</td><td>0</td><td>0.00%</td></tr><tr><td>4</td><td>0</td><td>0.00%</td></tr><tr><td>5</td><td>0</td><td>0.00%</td></tr><tr><td>6</td><td>0</td><td>0.00%</td></tr></tbody></table></div></div>
     <h2>Results</h2>
     <div style="overflow-x: auto;">
         <table id="resultsTable">


### PR DESCRIPTION
## Summary
- align summary and distribution tables side-by-side in `index.html`
- update HTML generator to wrap summary and distribution sections in flex containers

## Testing
- `pytest -q`
- `python - <<'PY'
import auto_lotto_main
auto_lotto_main.update_html_with_win_status_and_predict_number()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6861955e4d308324a43d5a4460246d77